### PR TITLE
TCS Labs Academy - PR 2: Learning Paths 1 & 2 (Foundations + AI Engineering)

### DIFF
--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/_index.md
@@ -1,0 +1,9 @@
+---
+type: "learning-path"
+title: "AI Engineering Foundations for Platform Engineers"
+description: "Understand how LLMs and coding agents actually work, prompt them well for cloud native operations, and ground them in your infrastructure's real state. The AI literacy that makes the rest of the academy click."
+id: "f40adb5d-2fc1-42dd-b3e7-96543b676498"
+banner: "banner.svg"
+weight: 2
+level: "beginner"
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/banner.svg
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/banner.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 220" role="img" aria-label="TCS Labs Academy">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b1f2a"/>
+      <stop offset="1" stop-color="#123642"/>
+    </linearGradient>
+    <linearGradient id="teal" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#00d3a7"/>
+      <stop offset="1" stop-color="#00b39f"/>
+    </linearGradient>
+  </defs>
+  <rect width="640" height="220" rx="14" fill="url(#bg)"/>
+  <rect x="0" y="0" width="8" height="220" fill="url(#teal)"/>
+  <!-- hexagon mark -->
+  <g transform="translate(96 110)">
+    <polygon points="0,-46 40,-23 40,23 0,46 -40,23 -40,-23" fill="none" stroke="url(#teal)" stroke-width="6"/>
+    <polygon points="0,-22 19,-11 19,11 0,22 -19,11 -19,-11" fill="url(#teal)" opacity="0.9"/>
+  </g>
+  <text x="170" y="96" font-family="Helvetica, Arial, sans-serif" font-size="40" font-weight="700" fill="#ffffff">TCS Labs Academy</text>
+  <text x="172" y="132" font-family="Helvetica, Arial, sans-serif" font-size="20" fill="#9fe8da">AI-Native Cloud Infrastructure with Meshery</text>
+  <text x="172" y="170" font-family="Helvetica, Arial, sans-serif" font-size="15" fill="#7fb6c4">LLMs &amp; coding agents for cloud native operations</text>
+</svg>

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/coding-agents-101/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/coding-agents-101/_index.md
@@ -1,0 +1,16 @@
+---
+type: "course"
+id: "coding-agents-101"
+title: "3. Coding Agents 101"
+description: "Understand what a coding agent is, how the agentic loop works, and how to apply agents safely to infrastructure operations with appropriate human oversight."
+weight: 3
+tags: ["ai", "agents"]
+categories: "AI"
+level: "intermediate"
+---
+
+Coding agents are the next step beyond chat-based LLM interaction. Instead of answering a single question, an agent can read files, execute commands, observe the results, and iterate - working through a task over multiple steps without requiring a prompt for each action.
+
+For platform engineers, this shift is significant. The same workflows you run manually - inspecting cluster state, diffing a configuration, applying a design, validating output - can be delegated to an agent that understands context, uses tools, and asks for approval before doing anything destructive.
+
+This course builds a complete mental model of coding agents: how they work internally, what tool use looks like in practice, how to apply them to real infrastructure tasks with Meshery, and how to keep a human in the loop where it matters. By the end, you will be equipped to evaluate and use agents for infrastructure work without treating them as a black box.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/coding-agents-101/agents/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/coding-agents-101/agents/_index.md
@@ -1,0 +1,10 @@
+---
+type: "module"
+id: "agents"
+title: "Agents"
+description: "How coding agents work, from the agentic loop and tool use to infrastructure applications and human-in-the-loop guardrails."
+weight: 1
+tags: ["agents"]
+categories: "AI"
+level: "intermediate"
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/coding-agents-101/agents/coding-agents-for-infrastructure/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/coding-agents-101/agents/coding-agents-for-infrastructure/_index.md
@@ -1,0 +1,92 @@
+---
+type: "page"
+id: "coding-agents-for-infrastructure"
+title: "Coding Agents for Infrastructure"
+description: "Apply the agentic loop to real infrastructure work with Meshery and Kubernetes, and understand where agents add value and where they need supervision."
+weight: 3
+---
+
+## Why Infrastructure Is a Good Fit
+
+Infrastructure work is unusually well-suited to agent-based automation. The reasons are structural:
+
+- **State is observable.** Kubernetes and Meshery expose rich, queryable APIs. An agent can read cluster state, Meshery designs, MeshSync data, and component status without scraping logs or guessing.
+- **Actions are declarative.** Applying a change means submitting a manifest or running a `mesheryctl` command - discrete, auditable actions with predictable schemas.
+- **Feedback is fast.** After applying a change, an agent can immediately query whether the desired state was reached. The reconciliation loop gives the agent a reliable signal.
+- **Failures are structured.** Kubernetes events, pod conditions, and Meshery's validation output are machine-readable. An agent can parse them without needing to understand free-form prose.
+
+This combination - observable state, declarative actions, fast feedback, structured failures - maps cleanly onto the plan-act-observe loop.
+
+## Reading Cluster and Meshery State
+
+Before proposing any change, a well-designed agent reads current state. Tools it might use:
+
+```bash
+# Check Meshery's connectivity and adapter status
+mesheryctl system check
+
+# List current designs registered in Meshery
+mesheryctl design list
+
+# Read cluster resources via kubectl
+kubectl get deployments -n production -o yaml
+
+# Query events for a specific workload
+kubectl get events --field-selector involvedObject.name=my-app -n production
+```
+
+An agent given these tools can construct a complete picture of the current state before deciding what to propose. This is the equivalent of a human operator running their pre-change checklist - except the agent does it every time, without skipping steps.
+
+MeshSync, Meshery's cluster synchronization component, continuously reconciles cluster state into Meshery's data model. An agent connected to Meshery via its API or MCP server can query MeshSync-derived state directly, without needing raw `kubectl` access.
+
+## Proposing and Applying Changes
+
+Once the agent understands current state, it can propose a change. The typical flow:
+
+1. Agent reads current state (cluster resources, Meshery design, policy constraints).
+2. Agent identifies the gap between current and desired state.
+3. Agent generates a candidate manifest or `mesheryctl` command sequence.
+4. Agent presents the proposal for human review (see the next lesson for the approval gate).
+5. Human approves; agent applies.
+
+For Meshery-managed infrastructure, the apply step often uses a design import:
+
+```bash
+mesheryctl design import -f designs/microservices-demo.yaml -s "Kubernetes Manifest"
+```
+
+Or a performance test against a defined profile:
+
+```bash
+mesheryctl perf apply --profile my-baseline-profile
+```
+
+The agent does not need to know the internals of these commands - it needs to know the tool definitions, which describe what parameters are required and what the command does. The framework handles execution.
+
+## What Agents Do Well
+
+| Task | Agent value |
+|---|---|
+| Summarizing cluster state | High - reads many resources, correlates across namespaces |
+| Identifying failing workloads | High - structured event data maps well to pattern matching |
+| Generating draft manifests | High - strong prior on Kubernetes YAML schemas |
+| Running performance tests | High - deterministic command, structured output |
+| Importing and validating designs | High - Meshery's validation output is structured |
+| Diagnosing network policy gaps | Medium - requires correlating policy with traffic data |
+| Root-cause analysis across logs | Medium - unstructured data, confidence varies |
+
+## Where Agents Need Supervision
+
+Not every infrastructure task is safe for autonomous execution. Watch for these patterns:
+
+**Irreversible actions.** Deleting a namespace, scaling a deployment to zero, removing a Meshery environment - these are hard to undo. Any agent action in this category should require explicit human approval.
+
+**Multi-cluster blast radius.** An agent given access to multiple clusters should have per-cluster permission scopes. A mistake in a staging cluster is recoverable; the same mistake in production may not be.
+
+**Configuration drift.** An agent that makes many small changes without a record can create a configuration that no one fully understands. All agent actions should be logged, and the resulting state should be captured in a Meshery design so it is version-controlled.
+
+**Novel failure modes.** If the agent encounters something it has not seen before - an unusual error, an unexpected API response - it should escalate rather than guess. An agent that confidently applies a fix to an unfamiliar failure mode is more dangerous than one that admits it does not know.
+
+The practical guidance: start with read-only tools. Add write tools one at a time, each behind an approval gate. Expand autonomy as you build confidence in the agent's behavior in your specific environment.
+
+You can practice this workflow by importing `designs/policy-guardrails.yaml` into Meshery and tasking an agent with validating the design against your cluster's current state - a read-only task with high signal value before you enable any write operations.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/coding-agents-101/agents/human-in-the-loop-and-guardrails/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/coding-agents-101/agents/human-in-the-loop-and-guardrails/_index.md
@@ -1,0 +1,96 @@
+---
+type: "page"
+id: "human-in-the-loop-and-guardrails"
+title: "Human-in-the-Loop and Guardrails"
+description: "Design approval gates, dry-run patterns, and permission boundaries that keep agents safe in production infrastructure environments."
+weight: 4
+---
+
+## Why Human-in-the-Loop Is Not Optional
+
+The agentic loop is powerful because it can act. It is also risky for the same reason. An agent that can run `kubectl delete` or `mesheryctl system stop` in a production environment is a sharp tool - valuable when used correctly, dangerous when used without guardrails.
+
+Human-in-the-loop (HITL) is not a failure mode or a concession that the agent is not good enough. It is an architectural decision: some actions have a blast radius large enough that a human should be the final authorization step, regardless of how confident the agent is. The goal is not to second-guess every action - it is to ensure that irreversible or high-impact actions always have a human sign-off.
+
+The practical benefit is also organizational. An agent that always asks before making production changes builds trust. An agent that surprises the on-call engineer with an unexpected deployment at 2 AM destroys it.
+
+## Approval Gates
+
+An approval gate is a point in the agentic loop where the agent pauses and presents its proposed action - with full context - to a human for a yes/no decision.
+
+A well-designed approval gate provides:
+
+- **What the agent intends to do** - the specific command or API call, with all parameters visible.
+- **Why** - the agent's reasoning, summarized in plain language.
+- **What it cannot undo** - an explicit statement of the blast radius.
+- **The diff, if applicable** - for manifest changes, a structured diff between current state and proposed state.
+
+```text
+Agent: I propose to apply the following change to the production namespace:
+
+  - Scale deployment/api-gateway from 2 replicas to 4
+  - Reason: p99 latency exceeded threshold in the last 15 minutes (observed: 620ms, threshold: 400ms)
+  - This action is reversible (scale back down to 2)
+
+Approve? [y/n]
+```
+
+The human's job at an approval gate is not to re-do the agent's analysis - it is to sanity-check the proposed action against their own knowledge of the environment. Did anything change in the last hour that the agent would not know about? Does this action conflict with a pending maintenance window? Is the reasoning sound?
+
+## Dry-Run Patterns
+
+Before committing a change, agents should use dry-run modes wherever available. Kubernetes supports server-side dry runs:
+
+```bash
+kubectl apply -f updated-deployment.yaml --dry-run=server
+```
+
+This validates the manifest against the API server - checking schema correctness, admission webhook results, and resource constraints - without persisting anything. An agent that always dry-runs before applying will catch a large class of errors before they affect running workloads.
+
+Meshery's design validation serves a similar role at the Meshery layer. Importing a design and running validation before deployment checks component relationships, policy constraints, and environment compatibility without making changes to the cluster.
+
+```bash
+mesheryctl design import -f designs/observability-stack.yaml -s "Kubernetes Manifest"
+# Then validate in the Meshery UI or via API before deploying
+```
+
+The dry-run result should be part of the approval gate context. Present the validation output alongside the proposed action so the human can see exactly what the API server and Meshery's policy engine think of the change.
+
+## Scope and Permission Limits
+
+The most reliable guardrail is a narrow permission scope. An agent that cannot do something cannot do it by accident.
+
+Design permission boundaries around:
+
+- **Namespace scope** - limit the agent to specific namespaces. An agent fixing a staging issue has no reason to touch the production namespace.
+- **Resource type** - an agent tasked with reading logs and describing pods does not need `delete` or `patch` permissions on any resource.
+- **Cluster scope** - if the agent manages multiple clusters, each cluster's credentials should be separate, with separate authorization decisions.
+- **Meshery environment** - Meshery's environments and workspaces let you group resources with distinct access controls. Use them to constrain an agent to its intended operating scope.
+
+Document the minimum permissions the agent needs and grant exactly those - not a broader role because it is convenient. The principle of least privilege applies as much to agents as to human operators.
+
+## Blast-Radius Thinking
+
+Before granting an agent access to any tool, ask: what is the worst thing it could do with this tool in a single action?
+
+| Tool | Worst case | Mitigation |
+|---|---|---|
+| `kubectl apply` | Apply a broken manifest to all namespaces | Require dry-run first; limit to specific namespaces |
+| `kubectl delete` | Delete a production namespace | Require approval; block delete on production namespaces |
+| `mesheryctl design import` | Import a design that conflicts with live policy | Validate before applying; use staging environment first |
+| `mesheryctl perf apply` | Run a load test against production | Scope to performance test environments only |
+
+Blast-radius thinking is not about being pessimistic - it is about being precise. The goal is to match the permission scope to the actual need, so that even a buggy or confused agent cannot cause more damage than the task requires.
+
+The reference design `designs/policy-guardrails.yaml` provides a worked example of policy constraints that can be imported into Meshery and used to validate agent-proposed changes before they are applied. Importing it is a useful starting exercise before enabling any write tools in your agent configuration.
+
+## Building Trust Incrementally
+
+The path to a useful, trusted agent is incremental:
+
+1. Read-only tools only. Verify the agent's reasoning is sound before it can touch anything.
+2. Write tools in non-production environments, behind approval gates.
+3. Write tools in production, behind approval gates and with dry-run required.
+4. Expand autonomy for specific, well-understood, reversible actions where the approval overhead exceeds the risk.
+
+Each expansion should be deliberate and documented. The goal is an agent that earns broader autonomy through demonstrated reliability - not one that starts with broad access and hopes for the best.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/coding-agents-101/agents/quiz.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/coding-agents-101/agents/quiz.md
@@ -1,0 +1,70 @@
+---
+title: "Module Quiz"
+passPercentage: 70
+type: "test"
+questions:
+  - id: "q1"
+    text: "What is the key difference between using an LLM in chat mode versus running a coding agent?"
+    type: "single-answer"
+    marks: 2
+    explanation: "A coding agent can call tools - reading files, running commands, and observing results - and loop over multiple steps to complete a task. Chat mode is a single-turn interaction with no tool access."
+    options:
+      - id: "a"
+        text: "A coding agent uses a larger language model."
+        isCorrect: false
+      - id: "b"
+        text: "A coding agent can invoke tools and iterate over multiple steps to complete a task."
+        isCorrect: true
+      - id: "c"
+        text: "A coding agent responds faster than chat mode."
+        isCorrect: false
+      - id: "d"
+        text: "A coding agent requires no prompts from the user."
+        isCorrect: false
+
+  - id: "q2"
+    text: "In the plan-act-observe loop, what happens immediately after the agent calls a tool?"
+    type: "single-answer"
+    marks: 2
+    explanation: "After the agent calls a tool, the framework executes it and appends the result (the observation) to the agent's context. The agent then returns to the plan step with updated context."
+    options:
+      - id: "a"
+        text: "The agent produces a final answer."
+        isCorrect: false
+      - id: "b"
+        text: "The loop terminates and waits for user input."
+        isCorrect: false
+      - id: "c"
+        text: "The tool result is appended to the context and the agent plans its next step."
+        isCorrect: true
+      - id: "d"
+        text: "The agent calls the next tool immediately without evaluating the result."
+        isCorrect: false
+
+  - id: "q3"
+    text: "Which of the following conditions should trigger a human approval gate before an agent proceeds?"
+    type: "multiple-answers"
+    marks: 2
+    explanation: "Deleting resources and scaling production deployments are irreversible or high-impact actions that warrant human approval. Reading pod logs and listing namespaces are read-only and low-risk."
+    options:
+      - id: "a"
+        text: "Reading pod logs in a development namespace."
+        isCorrect: false
+      - id: "b"
+        text: "Deleting a Kubernetes namespace."
+        isCorrect: true
+      - id: "c"
+        text: "Scaling a production deployment based on observed latency."
+        isCorrect: true
+      - id: "d"
+        text: "Listing namespaces across the cluster."
+        isCorrect: false
+
+  - id: "q4"
+    text: "What Meshery CLI command would you use to import and validate a design file before applying it to the cluster?"
+    type: "short-answer"
+    marks: 2
+    correctAnswer: "mesheryctl design import"
+    case_sensitive: false
+    explanation: "The command `mesheryctl design import -f <file> -s \"Kubernetes Manifest\"` imports and validates a design in Meshery before it is deployed to the cluster."
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/coding-agents-101/agents/the-agentic-loop-and-tool-use/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/coding-agents-101/agents/the-agentic-loop-and-tool-use/_index.md
@@ -1,0 +1,92 @@
+---
+type: "page"
+id: "the-agentic-loop-and-tool-use"
+title: "The Agentic Loop and Tool Use"
+description: "Understand the plan-act-observe loop, how function calling works under the hood, and how an agent decides when its task is done."
+weight: 2
+---
+
+## The Plan-Act-Observe Loop
+
+Every coding agent - regardless of which model powers it or which framework wraps it - runs the same fundamental loop:
+
+```text
+[ Receive task ]
+      |
+      v
+[ Plan: decide what to do next ]
+      |
+      v
+[ Act: call a tool OR produce a final answer ]
+      |
+      v
+[ Observe: receive the tool result ]
+      |
+      v
+[ Back to Plan, with updated context ]
+```
+
+This loop repeats until the agent either produces a final answer, runs out of allowed steps, or determines it cannot proceed without human input.
+
+The key insight is that the agent's "context window" - the text it reasons over - grows with each iteration. After acting and observing, the result is appended to the context, so the agent's next plan is informed by everything that happened before it. This is what makes multi-step reasoning possible: the agent is not re-reading a static document; it is reading a growing transcript of its own work.
+
+## Tool and Function Calling
+
+Modern LLMs support a feature called function calling (sometimes called tool use). At the API level, the caller provides a list of function definitions - name, description, and parameter schema. The model can then, as part of its response, emit a structured call to one of those functions instead of (or in addition to) natural language.
+
+A simplified tool definition looks like this:
+
+```yaml
+name: run_command
+description: "Run a shell command and return stdout and stderr."
+parameters:
+  command:
+    type: string
+    description: "The shell command to execute."
+```
+
+When the model decides to call this tool, it emits a structured object:
+
+```json
+{
+  "tool": "run_command",
+  "parameters": {
+    "command": "kubectl get pods -n production -o wide"
+  }
+}
+```
+
+The agent framework intercepts this, executes the actual command, and feeds the output back into the context as an "observation." The model never directly runs the command - the framework does. This is critical for safety: the framework can intercept, log, and gate every tool call before it executes.
+
+## How the Agent Decides What to Do
+
+The model's plan step is not random. It reasons from the task description, the conversation history, and the results of previous tool calls. In practice, a well-prompted agent will:
+
+1. Restate what it understands about the task.
+2. Identify what information it still needs.
+3. Select the tool most likely to provide that information.
+4. Call the tool with the appropriate parameters.
+5. Evaluate whether the result answers the question or whether another step is needed.
+
+This is not magic - it is pattern matching informed by training. The model has seen many examples of stepwise problem solving and generalizes from them. The quality of the plan is heavily influenced by the quality of the tool descriptions and the clarity of the initial task.
+
+## When the Agent Stops
+
+An agent terminates the loop when one of these conditions is true:
+
+- **Task complete:** The agent has a confident, complete answer and produces it as a final response.
+- **Blocked:** The agent cannot proceed without information or permission it does not have. A well-designed agent surfaces this explicitly rather than guessing.
+- **Step limit reached:** Most frameworks enforce a maximum number of loop iterations to prevent runaway agents. When the limit is hit, the agent is forced to report what it has so far.
+- **Human escalation:** The agent calls a special tool (e.g., `ask_human`) to request input, pausing the loop until the human responds.
+
+The stopping condition matters as much as the loop itself. An agent that never asks for help and never gives up will eventually do something wrong and keep going. Explicit termination logic - step limits, escalation tools, confidence thresholds - is a design requirement, not an afterthought.
+
+## Context Window and State
+
+Everything the agent knows during a task lives in its context window: the initial prompt, every tool call, every observation, and every intermediate plan. This is both the power and the limit of the agentic loop.
+
+The power: the agent's reasoning is fully auditable. You can read the full context and see exactly what information it had at each decision point.
+
+The limit: context windows are finite. Long-running tasks with many tool calls can exhaust the available context, degrading reasoning quality or causing the agent to lose track of early observations. For infrastructure tasks, this is a practical constraint - keep tasks focused, and break large tasks into smaller ones with clear handoff points.
+
+Understanding the loop, tool calling, and context management gives you the mental model to evaluate any agent implementation - whether you are building one, operating one, or reviewing one for production use.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/coding-agents-101/agents/what-is-a-coding-agent/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/coding-agents-101/agents/what-is-a-coding-agent/_index.md
@@ -1,0 +1,57 @@
+---
+type: "page"
+id: "what-is-a-coding-agent"
+title: "What Is a Coding Agent?"
+description: "Distinguish a coding agent from a chat assistant, understand what it can do with files and commands, and learn the spectrum of autonomy."
+weight: 1
+---
+
+## Agent vs Chat
+
+When you send a message to an LLM in chat mode, the model reads your message, generates a response, and stops. Every turn requires you to prompt it again. The model has no memory between sessions, cannot read your files, and cannot run anything - it can only produce text.
+
+A coding agent is different in three concrete ways:
+
+- **It can act, not just respond.** The agent is given a set of tools - functions it is allowed to call. A tool might read a file, write a file, list a directory, run a shell command, or query an API. After generating text, the agent can invoke one of these tools and receive back the result.
+- **It can loop.** After observing the result of a tool call, the agent generates its next step. This continues until the task is complete or the agent decides it is stuck and needs to ask the human.
+- **It has a task, not just a turn.** You give the agent a goal ("find the pod that is crashlooping and explain why"), and it works toward that goal across as many steps as required.
+
+The practical consequence for a platform engineer: you describe the outcome you want, and the agent handles the operational steps - reading logs, running commands, correlating results - rather than requiring you to run each command yourself and paste the output back in.
+
+## What an Agent Can Do
+
+The capabilities of any given agent depend entirely on which tools it has been given. Common tool categories include:
+
+| Tool category | Examples |
+|---|---|
+| File system | Read file, write file, list directory, search for pattern |
+| Shell execution | Run a command, capture stdout and stderr |
+| API calls | Query a REST endpoint, submit a manifest |
+| Memory / search | Retrieve relevant context from a vector store |
+| Human escalation | Ask the user a question, request approval |
+
+An agent running in your environment with shell access and `kubectl` configured can do a great deal: read pod logs, apply manifests, check node status, describe resources. The same model without those tools is just a text generator.
+
+This is an important separation of concerns. The model itself - its weights, its training - determines how well it reasons about what to do. The tools determine what it is actually permitted to do. Good agent design treats these independently: pick the right model for the reasoning task, and grant only the tools the task requires.
+
+## Levels of Autonomy
+
+Not every agent operates the same way. There is a spectrum from fully supervised to fully autonomous, and where you land should be a deliberate engineering decision, not an accident.
+
+**Fully supervised:** The agent proposes every action and waits for human approval before executing. Slow but safe. Good for early adoption, sensitive environments, or tasks where a wrong action is hard to undo.
+
+**Supervised with exceptions:** The agent acts autonomously within a defined scope (read-only, a single namespace, a staging environment) and escalates outside it. This is the most practical starting point for infrastructure work.
+
+**Checkpoint-based:** The agent runs freely but pauses at defined checkpoints - before applying any change, before deleting any resource - for a human to review a diff and approve.
+
+**Fully autonomous:** The agent acts without approval. Appropriate only for well-scoped, reversible tasks in environments where the blast radius of a mistake is negligible (generating a report, formatting a document).
+
+For infrastructure, fully autonomous operation on production systems is rarely appropriate. The value of an agent is not that it replaces human judgment - it is that it handles the mechanical work so the human judgment it does request is focused and informed.
+
+## Why the Distinction Matters
+
+Chat mode is useful for learning, drafting, and exploring ideas. Agent mode is useful for getting work done. The shift is not about the underlying model - it is about the architecture around it.
+
+When you hear "AI-assisted infrastructure operations," the operative word is not "AI" - it is "operations." An agent that can run `kubectl get events --field-selector reason=BackOff -A` and then read the relevant pod spec and then summarize the failure is doing work that would otherwise require a human to run three commands, correlate the output, and write a summary. That is the value proposition: mechanical steps handled automatically, human judgment applied at the right moment.
+
+Understanding this distinction - model vs agent, capability vs permission, supervised vs autonomous - is the foundation for everything else in this course.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/coding-agents-101/test.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/coding-agents-101/test.md
@@ -1,0 +1,108 @@
+---
+title: "Course Test"
+passPercentage: 70
+type: "test"
+questions:
+  - id: "q1"
+    text: "Which of the following best describes what a coding agent can do that a standard chat LLM cannot?"
+    type: "single-answer"
+    marks: 2
+    explanation: "A coding agent is given a set of tools it can call - such as reading files, running shell commands, or querying APIs - and loops over plan-act-observe cycles to complete a task. A chat LLM only generates text in a single turn."
+    options:
+      - id: "a"
+        text: "Generate longer responses with more detail."
+        isCorrect: false
+      - id: "b"
+        text: "Call tools, execute commands, and iterate across multiple steps to complete a task."
+        isCorrect: true
+      - id: "c"
+        text: "Access the internet in real time."
+        isCorrect: false
+      - id: "d"
+        text: "Use a different underlying model architecture."
+        isCorrect: false
+
+  - id: "q2"
+    text: "In the agentic loop, what is the purpose of the 'observe' step?"
+    type: "single-answer"
+    marks: 2
+    explanation: "The observe step appends the tool's output to the agent's context, giving it the information it needs to plan the next action. Without this step, the agent would not learn from what it just did."
+    options:
+      - id: "a"
+        text: "To pause the loop and wait for human approval."
+        isCorrect: false
+      - id: "b"
+        text: "To record the action in an audit log."
+        isCorrect: false
+      - id: "c"
+        text: "To append the tool result to the agent's context so it can plan the next step."
+        isCorrect: true
+      - id: "d"
+        text: "To determine whether the step limit has been reached."
+        isCorrect: false
+
+  - id: "q3"
+    text: "Which of the following are valid reasons to terminate an agentic loop before the task is complete?"
+    type: "multiple-answers"
+    marks: 2
+    explanation: "A step limit prevents runaway agents, and a blocked state (where the agent cannot proceed without information it lacks) is a valid reason to stop and escalate. Producing an intermediate result is not a termination condition - that is normal operation."
+    options:
+      - id: "a"
+        text: "The maximum number of allowed steps has been reached."
+        isCorrect: true
+      - id: "b"
+        text: "The agent has produced an intermediate result but has not finished."
+        isCorrect: false
+      - id: "c"
+        text: "The agent cannot proceed without information or permission it does not have."
+        isCorrect: true
+      - id: "d"
+        text: "The agent has called at least one tool."
+        isCorrect: false
+
+  - id: "q4"
+    text: "What is the primary reason to use `kubectl apply --dry-run=server` before an agent applies a manifest to a cluster?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Server-side dry run validates the manifest against the API server - checking schema, admission webhooks, and resource constraints - without persisting any change. This catches errors before they affect running workloads."
+    options:
+      - id: "a"
+        text: "To speed up the apply operation on the next run."
+        isCorrect: false
+      - id: "b"
+        text: "To validate the manifest against the API server without persisting any change."
+        isCorrect: true
+      - id: "c"
+        text: "To create a backup of the current cluster state."
+        isCorrect: false
+      - id: "d"
+        text: "To notify the human operator that a change is about to be applied."
+        isCorrect: false
+
+  - id: "q5"
+    text: "Which of the following best describes 'blast-radius thinking' in the context of agent permissions?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Blast-radius thinking means asking what the worst outcome of a given tool access would be in a single action, then scoping permissions so that even a buggy or confused agent cannot cause damage beyond what the task requires."
+    options:
+      - id: "a"
+        text: "Estimating how fast the agent can complete its task."
+        isCorrect: false
+      - id: "b"
+        text: "Calculating the number of tool calls in the agentic loop."
+        isCorrect: false
+      - id: "c"
+        text: "Assessing the worst-case impact of a tool access and constraining permissions accordingly."
+        isCorrect: true
+      - id: "d"
+        text: "Measuring the agent's confidence score before it takes an action."
+        isCorrect: false
+
+  - id: "q6"
+    text: "Which Meshery command would you run to check that Meshery's adapters and cluster connectivity are healthy before delegating infrastructure tasks to an agent?"
+    type: "short-answer"
+    marks: 2
+    correctAnswer: "mesheryctl system check"
+    case_sensitive: false
+    explanation: "The `mesheryctl system check` command validates Meshery's operational status, including adapter connectivity and cluster reachability, making it the appropriate pre-flight step before running agent-driven infrastructure tasks."
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/exam.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/exam.md
@@ -1,0 +1,176 @@
+---
+title: "Learning Path Exam"
+passPercentage: 70
+timeLimit: 30
+type: "test"
+questions:
+  - id: "q1"
+    text: "At its core, what does a large language model do?"
+    type: "single-answer"
+    marks: 2
+    explanation: "An LLM predicts the next token given the preceding context; everything else is built on that."
+    options:
+      - id: "a"
+        text: "Looks answers up in a database"
+        isCorrect: false
+      - id: "b"
+        text: "Predicts the next token given the preceding context"
+        isCorrect: true
+      - id: "c"
+        text: "Executes code deterministically"
+        isCorrect: false
+      - id: "d"
+        text: "Compiles YAML into binaries"
+        isCorrect: false
+  - id: "q2"
+    text: "What is the 'context window'?"
+    type: "single-answer"
+    marks: 2
+    explanation: "The context window is the maximum amount of text (in tokens) the model can consider at once."
+    options:
+      - id: "a"
+        text: "The model's training dataset"
+        isCorrect: false
+      - id: "b"
+        text: "The maximum amount of text (tokens) the model can consider at once"
+        isCorrect: true
+      - id: "c"
+        text: "A UI panel in the terminal"
+        isCorrect: false
+      - id: "d"
+        text: "The GPU memory size"
+        isCorrect: false
+  - id: "q3"
+    text: "Which are real LLM failure modes to guard against in operations? (Select all that apply.)"
+    type: "multiple-answers"
+    marks: 3
+    explanation: "Hallucination, confident wrongness, and stale knowledge are all real failure modes. 'Deterministic output' is not a failure mode (and LLM output is generally not deterministic)."
+    options:
+      - id: "a"
+        text: "Hallucinating commands or fields that do not exist"
+        isCorrect: true
+      - id: "b"
+        text: "Being confidently wrong"
+        isCorrect: true
+      - id: "c"
+        text: "Relying on stale training knowledge"
+        isCorrect: true
+      - id: "d"
+        text: "Producing perfectly deterministic output every time"
+        isCorrect: false
+  - id: "q4"
+    text: "Why ground a prompt in live cluster/Meshery state instead of relying on the model's memory?"
+    type: "single-answer"
+    marks: 2
+    explanation: "The model's training data is generic and stale; grounding in current, specific state produces accurate, relevant answers."
+    options:
+      - id: "a"
+        text: "It makes the response longer"
+        isCorrect: false
+      - id: "b"
+        text: "Current, specific state yields accurate, relevant answers; training data is stale"
+        isCorrect: true
+      - id: "c"
+        text: "It disables hallucination entirely"
+        isCorrect: false
+      - id: "d"
+        text: "It is required by Kubernetes"
+        isCorrect: false
+  - id: "q5"
+    text: "Which instruction most reliably yields a parseable design artifact from an LLM?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Constraining the output ('output only YAML, no commentary') yields a clean, directly usable artifact."
+    options:
+      - id: "a"
+        text: "'Explain your reasoning in detail'"
+        isCorrect: false
+      - id: "b"
+        text: "'Output only valid YAML, no commentary'"
+        isCorrect: true
+      - id: "c"
+        text: "'Be creative with the format'"
+        isCorrect: false
+      - id: "d"
+        text: "'Use as many tokens as possible'"
+        isCorrect: false
+  - id: "q6"
+    text: "Describe the agentic loop in three words (one common phrasing)."
+    type: "short-answer"
+    marks: 2
+    correctAnswer: "plan act observe"
+    case_sensitive: false
+    explanation: "A coding agent repeatedly plans, acts (calls a tool), and observes the result until the task is done."
+  - id: "q7"
+    text: "What distinguishes a coding agent from a plain chat assistant?"
+    type: "single-answer"
+    marks: 2
+    explanation: "An agent can take actions through tools - reading/writing files and running commands - not just produce text."
+    options:
+      - id: "a"
+        text: "It can take actions via tools (files, shell, APIs), not just produce text"
+        isCorrect: true
+      - id: "b"
+        text: "It uses a larger font"
+        isCorrect: false
+      - id: "c"
+        text: "It never makes mistakes"
+        isCorrect: false
+      - id: "d"
+        text: "It runs without any model"
+        isCorrect: false
+  - id: "q8"
+    text: "Why keep a human in the loop for agent-driven infrastructure changes?"
+    type: "single-answer"
+    marks: 2
+    explanation: "A human reviews and approves changes before they apply, bounding blast radius and keeping accountability."
+    options:
+      - id: "a"
+        text: "To slow the agent down for no reason"
+        isCorrect: false
+      - id: "b"
+        text: "To review and approve changes before they apply, bounding blast radius"
+        isCorrect: true
+      - id: "c"
+        text: "Because agents cannot run commands"
+        isCorrect: false
+      - id: "d"
+        text: "To increase token usage"
+        isCorrect: false
+  - id: "q9"
+    text: "In retrieval-augmented generation for ops, what is 'retrieval'?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Retrieval fetches relevant, current information (state, runbooks, designs) and supplies it to the model as context."
+    options:
+      - id: "a"
+        text: "Fetching relevant current information and supplying it to the model as context"
+        isCorrect: true
+      - id: "b"
+        text: "Retraining the model on your data nightly"
+        isCorrect: false
+      - id: "c"
+        text: "Deleting old logs"
+        isCorrect: false
+      - id: "d"
+        text: "Compressing container images"
+        isCorrect: false
+  - id: "q10"
+    text: "Before trusting an infrastructure agent with real changes, you should evaluate it. Which practices help? (Select all that apply.)"
+    type: "multiple-answers"
+    marks: 3
+    explanation: "Golden tasks, an eval harness, and safety checks (dry-run, approvals) all build justified trust. 'Skipping all testing' does the opposite."
+    options:
+      - id: "a"
+        text: "Define golden tasks with known-good outcomes"
+        isCorrect: true
+      - id: "b"
+        text: "Run an eval harness across fixtures"
+        isCorrect: true
+      - id: "c"
+        text: "Gate real changes behind dry-runs and approvals"
+        isCorrect: true
+      - id: "d"
+        text: "Skip all testing to move faster"
+        isCorrect: false
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/how-llms-work-for-infrastructure-engineers/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/how-llms-work-for-infrastructure-engineers/_index.md
@@ -1,0 +1,16 @@
+---
+type: "course"
+id: "how-llms-work-for-infrastructure-engineers"
+title: "1. How LLMs Work for Infrastructure Engineers"
+description: "Build a practical mental model of large language models - what they actually do, where they break, and how to choose one for infrastructure tasks. No hype, just the mechanics you need to use LLMs confidently with Meshery."
+weight: 1
+tags: ["ai", "llm"]
+categories: "AI"
+level: "beginner"
+---
+
+Large language models are probability engines that predict the next token in a sequence - not knowledge databases, not reasoning systems, and certainly not reliable sources of ground truth about your cluster state. Before you wire one into a Meshery workflow, you need a clear picture of the mechanism underneath.
+
+This course strips away the marketing language and gives you the mental model that matters for ops work: how next-token prediction produces useful outputs, what tokens and context windows mean for how much infrastructure state you can pass in, where LLMs fail confidently and why that matters more than where they succeed, and how to match model capability to the actual task at hand - classification, generation, or structured reasoning.
+
+By the end you will be able to describe what an LLM is actually doing when you prompt it, predict where it will produce plausible-sounding nonsense, and make an informed choice about which model to attach to a given infrastructure automation task.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/how-llms-work-for-infrastructure-engineers/llm-basics/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/how-llms-work-for-infrastructure-engineers/llm-basics/_index.md
@@ -1,0 +1,10 @@
+---
+type: "module"
+id: "llm-basics"
+title: "LLM Basics"
+description: "Core mechanics of large language models for platform and infrastructure engineers who need to use them without being misled by them."
+weight: 1
+tags: ["ai"]
+categories: "AI"
+level: "beginner"
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/how-llms-work-for-infrastructure-engineers/llm-basics/choosing-a-model-for-infra-tasks/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/how-llms-work-for-infrastructure-engineers/llm-basics/choosing-a-model-for-infra-tasks/_index.md
@@ -1,0 +1,83 @@
+---
+type: "page"
+id: "choosing-a-model-for-infra-tasks"
+title: "Choosing a Model for Infrastructure Tasks"
+description: "Capability vs latency vs cost, when a smaller model suffices, and how to match model to task - classification, generation, and reasoning."
+weight: 4
+---
+
+Not every infrastructure task requires the largest, most expensive model available. Choosing the wrong model in either direction - overprovisioned for a simple task, or underpowered for a complex one - wastes money, adds latency, or produces poor results. This lesson gives you a framework for making that choice deliberately.
+
+## The Three Axes of Model Selection
+
+Model selection is always a tradeoff across three dimensions:
+
+**Capability** - how well the model performs on the task type. Larger models with more parameters generally handle complex multi-step reasoning better. Smaller models are often adequate for pattern classification, short-form generation, and tasks with well-defined structure.
+
+**Latency** - how long the model takes to produce output. For interactive use or real-time pipelines, a model that takes 10 seconds per response is a problem even if its output is excellent. Smaller models are faster; quantized models trade some accuracy for speed.
+
+**Cost** - what you pay per token. API pricing varies by an order of magnitude or more across model tiers. Running a large model at high token volumes for a task a smaller model handles equally well is straightforward waste.
+
+These three dimensions interact. The highest-capability model is typically the highest-latency and highest-cost option. A small, fast, cheap model may be fully sufficient for the task at hand.
+
+## Matching Model to Task Type
+
+A useful first-pass framework: categorize the task before selecting a model.
+
+### Classification Tasks
+
+Classification takes input and assigns it to a category. Examples relevant to infrastructure work:
+
+- Determining whether a log line represents an error, warning, or informational event
+- Identifying which Meshery component type a user description refers to
+- Routing a support request to the right team
+
+Classification tasks have clear right answers, short outputs, and do not require extended chains of reasoning. Small, fast models handle these well. Running a frontier reasoning model for log classification is overprovisioning.
+
+### Generation Tasks
+
+Generation takes a specification or description and produces text or structured output. Examples:
+
+- Drafting a Kubernetes manifest from a description
+- Writing a first version of a Meshery design for import with `mesheryctl design import -f <file> -s "Kubernetes Manifest"`
+- Generating Prometheus alerting rules from a description of the SLO
+
+Generation tasks benefit from larger models when the output needs to be syntactically valid (YAML, JSON), technically accurate, and complete. A model with weaker coding capability will produce more hallucinated fields and invalid syntax. For generation of structured infrastructure artifacts, use a model in the mid-to-upper capability tier and validate its output programmatically.
+
+### Reasoning Tasks
+
+Reasoning tasks require multi-step inference: comparing tradeoffs, diagnosing a root cause across multiple symptoms, or deciding which of several approaches best fits a set of constraints. Examples:
+
+- Analyzing the output of `mesheryctl system check` and identifying the most likely root cause across several warnings
+- Recommending a network policy configuration that satisfies multiple security requirements
+- Evaluating whether a proposed design change is consistent with an organization's policy guardrails
+
+Reasoning tasks are where the capability gap between model tiers is most pronounced. A small model producing plausible-sounding reasoning output is more dangerous than one that produces clearly wrong output - the errors are harder to spot. Use larger models for reasoning tasks, and structure your prompts to make the reasoning visible (ask for step-by-step analysis, not just a conclusion).
+
+## When a Smaller Model Is the Right Choice
+
+Smaller models are underused in infrastructure automation. Consider them when:
+
+- The task is well-scoped with a short, structured output
+- You are running the model on-premises or on edge infrastructure where GPU resources are limited
+- You have fine-tuned a smaller model on your specific infrastructure corpus and it outperforms a general-purpose larger model on your tasks
+- Latency matters more than maximum accuracy - for example, in a real-time incident triage assistant
+
+Self-hosted smaller models also eliminate the data residency concerns that arise when sending cluster state or policy documents to a third-party API.
+
+## A Decision Framework
+
+Before picking a model, answer these four questions:
+
+| Question | Implication |
+|---|---|
+| What type of task is this - classification, generation, or reasoning? | Sets the minimum capability floor |
+| What is the acceptable latency? | Eliminates high-latency options for real-time use |
+| What volume of tokens will this run at? | Surfaces cost constraints |
+| Is the output going directly into a production system? | Increases the required capability tier for safety |
+
+For most initial Meshery automation workflows - drafting designs, summarizing check output, routing commands - a mid-tier model is a reasonable starting point. Run evals on your specific prompts and data before committing to a model for production use. Evaluation is covered in a later course in this learning path.
+
+## Capability Changes Quickly
+
+Model capabilities evolve rapidly. A model that was the clear winner for code generation six months ago may have been overtaken. Treat your model selection as a configuration decision you revisit quarterly, not a permanent architectural choice. Keep the model identifier in configuration rather than hardcoded, and design your prompts to be model-agnostic where possible.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/how-llms-work-for-infrastructure-engineers/llm-basics/quiz.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/how-llms-work-for-infrastructure-engineers/llm-basics/quiz.md
@@ -1,0 +1,81 @@
+---
+title: "Module Quiz"
+passPercentage: 70
+type: "test"
+questions:
+  - id: "q1"
+    text: "What is the core mechanism by which an LLM produces output?"
+    type: "single-answer"
+    marks: 2
+    explanation: "An LLM is a neural network that predicts the most probable next token given the preceding sequence of tokens. It does not retrieve facts from a database or perform deterministic lookups."
+    options:
+      - id: "a"
+        text: "It queries a structured knowledge base and returns matching facts"
+        isCorrect: false
+      - id: "b"
+        text: "It predicts the most probable next token based on all preceding tokens"
+        isCorrect: true
+      - id: "c"
+        text: "It executes a set of logical inference rules over a symbolic knowledge graph"
+        isCorrect: false
+      - id: "d"
+        text: "It searches training data at inference time to find the closest matching example"
+        isCorrect: false
+
+  - id: "q2"
+    text: "Which of the following best explains why an LLM may recommend a flag that does not exist in the mesheryctl CLI?"
+    type: "single-answer"
+    marks: 2
+    explanation: "LLMs generate statistically likely token sequences. If a flag name pattern looks plausible based on training data, the model will produce it whether or not it actually exists. This is hallucination - confident, fluent output that is factually wrong."
+    options:
+      - id: "a"
+        text: "The model has access to an outdated version of the mesheryctl documentation"
+        isCorrect: false
+      - id: "b"
+        text: "The model generates statistically plausible text regardless of whether the content is accurate"
+        isCorrect: true
+      - id: "c"
+        text: "The model is deliberately testing whether the user will verify its output"
+        isCorrect: false
+      - id: "d"
+        text: "The model misread the user's prompt and answered a different question"
+        isCorrect: false
+
+  - id: "q3"
+    text: "A Meshery design with 10 components serializes to approximately 2,000 tokens. You also want to include a 3,000-token policy document and a 500-token system prompt. Which of the following statements is true?"
+    type: "single-answer"
+    marks: 2
+    explanation: "The total input is 5,500 tokens. Both input and output tokens count against the context window, so you must also leave room for the model's response. A model with an 8K context window would have less than 3,000 tokens remaining for output, which may be insufficient for detailed analysis. Planning the token budget before sending a request prevents truncation."
+    options:
+      - id: "a"
+        text: "Context window limits only apply to the model's output, not the input"
+        isCorrect: false
+      - id: "b"
+        text: "The total input of 5,500 tokens leaves limited room for model output in smaller context windows"
+        isCorrect: true
+      - id: "c"
+        text: "Token counts are irrelevant because modern models have unlimited context"
+        isCorrect: false
+      - id: "d"
+        text: "Only the system prompt counts against the context window"
+        isCorrect: false
+
+  - id: "q4"
+    text: "Which task types are well-suited to smaller, faster LLMs rather than large frontier models? Select all that apply."
+    type: "multiple-answers"
+    marks: 2
+    explanation: "Classification tasks (assigning inputs to categories) and short structured output generation are well-suited to smaller models because they have bounded, well-defined correct outputs. Multi-step root cause reasoning across complex system state benefits from larger models where the capability gap is most pronounced."
+    options:
+      - id: "a"
+        text: "Classifying log lines as error, warning, or informational"
+        isCorrect: true
+      - id: "b"
+        text: "Multi-step root cause analysis across a distributed system incident"
+        isCorrect: false
+      - id: "c"
+        text: "Routing a support request to the correct team based on its content"
+        isCorrect: true
+      - id: "d"
+        text: "Evaluating whether a proposed network policy satisfies multiple security constraints simultaneously"
+        isCorrect: false
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/how-llms-work-for-infrastructure-engineers/llm-basics/strengths-and-failure-modes/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/how-llms-work-for-infrastructure-engineers/llm-basics/strengths-and-failure-modes/_index.md
@@ -1,0 +1,64 @@
+---
+type: "page"
+id: "strengths-and-failure-modes"
+title: "Strengths and Failure Modes"
+description: "Hallucination, confident wrongness, stale knowledge, and non-determinism - why verification and human-in-the-loop are non-negotiable for infrastructure automation."
+weight: 3
+---
+
+A tool's failure modes tell you more about how to use it safely than its strengths do. LLMs have characteristic ways of going wrong that are especially dangerous in infrastructure contexts, because the consequences of acting on wrong output are not "the document looks funny" - they are "the deployment went sideways" or "the policy rule is silently bypassed."
+
+## Hallucination
+
+Hallucination is the canonical LLM failure mode: the model produces output that is fluent, confident, and factually wrong. The word "hallucination" is somewhat misleading because it implies the model is confused. A more accurate description is that the model is doing exactly what it is designed to do - producing statistically likely token sequences - and the sequence it produces happens to describe something that does not exist.
+
+For infrastructure engineers, hallucination shows up as:
+
+- **Invented command flags** - the LLM generates `mesheryctl design apply --force --namespace production` when no `--force` flag exists for that subcommand
+- **Fabricated API fields** - a generated YAML manifest includes a field that does not exist in the CRD spec
+- **Made-up version numbers** - the LLM cites a release version or changelog entry that was never published
+- **Non-existent integrations** - the model describes a Meshery adapter or provider that was never written
+
+None of these look like errors. They look like documentation. That is what makes hallucination dangerous.
+
+**Mitigation:** Verify every generated command against [docs.meshery.io](https://docs.meshery.io) before running it. Validate generated YAML with `kubectl apply --dry-run=client` or Meshery's built-in validation before applying it to a cluster. Treat LLM output as a draft, not a source of truth.
+
+## Confident Wrongness
+
+Hallucination is a special case of a broader pattern: LLMs express confidence that is unrelated to correctness. The model does not have an internal accuracy signal. It does not know what it does not know. A response that is completely correct and a response that is completely fabricated are produced by the same mechanism and often sound identical.
+
+This is qualitatively different from a human expert who says "I'm not sure about this, you should check." An LLM will typically not volunteer uncertainty unless you explicitly ask it to, and even then the uncertainty it expresses may not correlate with actual accuracy.
+
+**Mitigation:** Build verification into your workflow, not just into your judgment. If you are building an agent that generates Meshery designs, include a validation step - run `mesheryctl system check` after any system change, import the design and inspect it in Kanvas before applying it to a live environment.
+
+## Stale Knowledge
+
+LLM weights are frozen at a training cutoff date. A model trained in mid-2024 has no knowledge of software released, CVEs published, or API changes made after that date. The training cutoff is not always clearly documented and is not always respected consistently even when it is - models sometimes confidently describe behavior from an earlier version of a project.
+
+For infrastructure work, stale knowledge creates specific risks:
+
+- Security advisories that postdate the training cutoff are unknown to the model
+- Deprecated API versions may be recommended without any warning
+- A Meshery feature introduced in a recent release will be either unknown or incorrectly described
+
+**Mitigation:** Pass current documentation as context when accuracy on recent behavior matters. Use the MCP server pattern (covered in a later course) to give an agent access to live documentation queries rather than relying on baked-in training knowledge.
+
+## Non-Determinism
+
+Given the same prompt, an LLM will typically not produce the same output twice. The sampling process that picks each token includes randomness controlled by a parameter called temperature. At temperature zero the output is deterministic (always the highest-probability token), but most deployed models run at temperatures above zero to produce more varied, natural-sounding responses.
+
+For infrastructure automation, non-determinism means:
+
+- The same prompt that generated a valid YAML manifest yesterday may generate an invalid one today
+- Automated pipelines that rely on LLM output must validate that output programmatically, not assume consistency
+- Comparing outputs across runs is unreliable for detecting regressions
+
+**Mitigation:** Lower temperature settings produce more consistent output at the cost of some creativity. For structured output tasks - generating YAML, writing policy rules, producing JSON - use the lowest temperature your model supports and use output schemas or structured output modes where the API offers them. Always validate the structure of LLM output programmatically before use.
+
+## Human-in-the-Loop Is Not Optional
+
+The combination of these failure modes - confident, plausible, non-deterministic, potentially stale output - means that any infrastructure workflow where an LLM can directly apply changes to production systems without human review is a reliability risk.
+
+Human-in-the-loop does not mean a human reads every token. It means the workflow is designed so that a human can inspect and approve the LLM's proposed action before it takes effect. In Meshery terms: the agent drafts a design or proposes a configuration change, you review it in Kanvas or inspect it with `mesheryctl design view`, and you apply it deliberately.
+
+This is not a temporary limitation waiting to be solved by a better model. It is the correct operational posture given how the technology works. Build verification and approval steps into your architecture from the start.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/how-llms-work-for-infrastructure-engineers/llm-basics/tokens-context-windows-and-limits/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/how-llms-work-for-infrastructure-engineers/llm-basics/tokens-context-windows-and-limits/_index.md
@@ -1,0 +1,67 @@
+---
+type: "page"
+id: "tokens-context-windows-and-limits"
+title: "Tokens, Context Windows, and Limits"
+description: "What tokens are, how context windows bound every LLM interaction, and what that means for how much infrastructure state you can feed an LLM at once."
+weight: 2
+---
+
+Every constraint you will hit when using an LLM for infrastructure tasks flows from two things: tokens and context windows. Understanding them prevents wasted prompts, unexpected truncation, and surprising cost spikes.
+
+## What a Token Is
+
+A token is the unit a language model reads and writes. Tokenization splits text into chunks before the model ever sees it. For English prose, one token is roughly 3-4 characters, or about 0.75 words on average. For structured text like YAML, JSON, or shell output, the ratio is less favorable because symbols, whitespace, and repeated keys each consume tokens.
+
+Some practical benchmarks for infrastructure text:
+
+| Content | Approximate Tokens |
+|---|---|
+| 1 line of shell output | 10-30 |
+| A 20-line YAML deployment manifest | 200-350 |
+| `kubectl get pods -A` output for 50 pods | 800-1,200 |
+| A full Meshery design with 10 components | 1,500-3,000 |
+| A 100-line Prometheus alerting rules file | 500-900 |
+
+These are rough estimates. The exact count depends on the tokenizer used by the specific model, and tokenizers differ between model families. Most LLM APIs expose a token-counting endpoint you can call before committing to a request.
+
+## What a Context Window Is
+
+The context window is the maximum number of tokens the model can process in a single request - input plus output combined. Every token in your prompt, every token in any conversation history you include, and every token in the model's response comes out of this shared budget.
+
+Context window sizes have grown substantially. A small model might have an 8K-token window; many current models sit at 128K tokens or more. One model family used in coding agents supports up to 1 million tokens. These numbers sound large until you start feeding real infrastructure state into a prompt.
+
+Consider a realistic workflow: you want an LLM to review your `designs/microservices-demo.yaml` Meshery design against a security policy. If the design serializes to 2,000 tokens and the policy document is 3,000 tokens, you have used 5,000 tokens before writing a single instruction. Add conversation history, system prompt, and output space - you are using a meaningful fraction of a 32K window.
+
+## Why Context Limits Matter for Infrastructure Work
+
+Infrastructure state is verbose. YAML is verbose. Log output is verbose. The artifacts you want to hand an LLM are often large.
+
+Three practical consequences:
+
+**Truncation is silent.** If your input exceeds the context window, the API will either return an error or silently truncate the input. Silent truncation is the dangerous case - the model receives an incomplete picture and produces output based on a partial view of your system. Always check that your prompt fits within the model's limit before sending.
+
+**More context costs more.** Most hosted LLM APIs price on tokens in plus tokens out. Feeding the entire output of `kubectl get all -n production` into every prompt is expensive. Design your prompts to include only the state relevant to the question.
+
+**Context is stateless across requests.** Each API call starts with a fresh context. The model has no memory of previous calls unless you explicitly include prior conversation in the new prompt. If your agent is having a multi-turn conversation with the LLM, each turn must carry all relevant prior context as tokens.
+
+## Strategies for Infrastructure State
+
+When you need to give an LLM information about your cluster or Meshery environment, you have several options:
+
+**Trim the input.** Instead of passing raw `kubectl get pods -A` output, filter to the namespace or resource type that is actually relevant. Pass `kubectl get pods -n observability --field-selector=status.phase!=Running` when you are troubleshooting non-running pods.
+
+**Use structured summaries.** An agent can call `mesheryctl system check` and pass only the warning and error lines to the LLM, rather than the full output.
+
+**Import and reference designs.** Meshery designs provide a compact, structured representation of infrastructure intent. Instead of pasting raw Kubernetes manifests, import a design with:
+
+```bash
+mesheryctl design import -f designs/microservices-demo.yaml -s "Kubernetes Manifest"
+```
+
+Then reference the design by name in your prompt. The LLM receives a focused description rather than a sprawling manifest dump.
+
+**Use RAG for large corpora.** If you need the LLM to reason about a large body of documentation - a whole runbook, a policy library, all your alerting rules - retrieval-augmented generation lets you fetch only the relevant chunks at query time rather than loading everything into the context window. This is covered in a later course.
+
+## Context Window as a Design Constraint
+
+When you build any agentic workflow around Meshery, treat the context window as a first-class design constraint - the same way you would treat a memory limit or a request timeout. Before writing a single line of prompt, ask: what is the minimum state the LLM needs to complete this task, and does it fit? Design toward the minimum.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/how-llms-work-for-infrastructure-engineers/llm-basics/what-is-an-llm/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/how-llms-work-for-infrastructure-engineers/llm-basics/what-is-an-llm/_index.md
@@ -1,0 +1,52 @@
+---
+type: "page"
+id: "what-is-an-llm"
+title: "What Is an LLM?"
+description: "A practical mental model of large language models - next-token prediction, training vs inference, and what LLMs are and are not good at for operations work."
+weight: 1
+---
+
+If you are going to use an LLM as part of a Meshery automation workflow, you need a working mental model of what it actually does. Not a marketing summary - a mechanical description you can reason from when things go wrong.
+
+## The Core Mechanism: Next-Token Prediction
+
+An LLM is a neural network trained to predict the most probable next token given a sequence of preceding tokens. That is the whole game. When you send a prompt, the model reads your input and emits tokens one at a time, each token selected based on probability distributions computed from everything that came before.
+
+A token is roughly 3-4 characters of English text. "Meshery" is one token. "kubectl" is one token. A YAML block with 50 keys might consume 400-600 tokens. This matters when you are trying to feed cluster state into a prompt.
+
+The model does not retrieve facts. It does not query a database. It does not look things up. It produces text that is statistically consistent with patterns seen during training. When the output looks like a fact, it is because similar text appeared in training data - not because the model verified anything.
+
+## Training vs Inference
+
+These two phases are completely different in cost, time, and purpose.
+
+**Training** is the process of adjusting billions of numerical weights in the neural network so that next-token predictions improve across a huge corpus of text. Training a frontier model requires weeks of compute across thousands of GPUs and costs tens to hundreds of millions of dollars. You are not doing this.
+
+**Inference** is the process of running the trained model on new input to produce output. This is what happens every time you send a prompt. Inference is comparatively cheap - milliseconds to seconds per response depending on output length and model size - and it is what you are paying for when you call an LLM API.
+
+The distinction matters operationally: you cannot change what a model knows by talking to it. Knowledge is baked into weights at training time. If the model was trained before a Meshery release, it has no knowledge of features introduced in that release. The only way to give an LLM current information is to put that information in the prompt - which is the premise behind retrieval-augmented generation (RAG) and tool-equipped agents.
+
+## What LLMs Are Actually Good At for Ops Work
+
+LLMs excel at tasks that require generating or transforming text according to patterns:
+
+- **Drafting YAML and configuration** - given a description, an LLM can produce a plausible first draft of a Kubernetes manifest or Meshery design that you then verify and apply
+- **Explaining unfamiliar resources** - paste a CRD or an error log and ask what it means
+- **Pattern matching across text** - classify log lines by severity, summarize a long policy document, extract structured data from unstructured output
+- **Translating between formats** - convert a Helm values file into equivalent Meshery design parameters
+- **Suggesting next steps** - given the output of `mesheryctl system check`, suggest what to investigate next
+
+Notice what all these have in common: the output needs human review before it has operational effect.
+
+## What LLMs Are Not Good At for Ops Work
+
+- **Ground truth about live systems** - an LLM has no access to your cluster unless you explicitly pass state into the prompt. It cannot tell you what is currently running.
+- **Deterministic arithmetic and bit-level operations** - token prediction is probabilistic; exact calculations can and do go wrong
+- **Up-to-date information** - training cutoffs are real. A model trained six months ago does not know about a CVE published last week.
+- **Authoritative command syntax** - flags change, APIs version, defaults shift. Always verify generated commands against current documentation at [docs.meshery.io](https://docs.meshery.io).
+
+## The Right Mental Model
+
+Think of an LLM as a very fast, very well-read collaborator who has read most of the internet but cannot see your screen, has not worked at your company, and occasionally states incorrect things with complete confidence. It is useful precisely because of the reading - and dangerous for the same reason it is useful, because it produces fluent output whether or not the content is correct.
+
+This is not a flaw to work around. It is the nature of the mechanism. Your job as the infrastructure engineer is to design workflows where LLM output is checked before it acts on production systems. The lessons that follow will give you the vocabulary to do that well.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/how-llms-work-for-infrastructure-engineers/test.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/how-llms-work-for-infrastructure-engineers/test.md
@@ -1,0 +1,107 @@
+---
+title: "Course Test"
+passPercentage: 70
+type: "test"
+questions:
+  - id: "q1"
+    text: "What is the fundamental difference between LLM training and LLM inference?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Training adjusts the model's weights across a large corpus and happens once, at enormous cost. Inference runs the frozen trained model on a new input to produce output. You cannot update what a model knows by talking to it - knowledge is fixed at training time."
+    options:
+      - id: "a"
+        text: "Training uses GPU clusters; inference uses CPU clusters"
+        isCorrect: false
+      - id: "b"
+        text: "Training adjusts model weights using a corpus; inference runs the frozen model on new input"
+        isCorrect: true
+      - id: "c"
+        text: "Training is fast and cheap; inference is slow and expensive"
+        isCorrect: false
+      - id: "d"
+        text: "Training happens on your prompt; inference happens on the training dataset"
+        isCorrect: false
+
+  - id: "q2"
+    text: "An LLM generates a Meshery design manifest that includes a component field named `spec.meshSync.autoDiscovery.enabled`. You cannot find this field in the Meshery documentation. What is the most likely explanation?"
+    type: "single-answer"
+    marks: 2
+    explanation: "This is a hallucinated field. The LLM produced a plausible-looking field name based on patterns in its training data, but the field does not exist. This is why generated YAML must be validated against the actual schema before use."
+    options:
+      - id: "a"
+        text: "The field exists but is undocumented"
+        isCorrect: false
+      - id: "b"
+        text: "The field was removed in a recent Meshery release"
+        isCorrect: false
+      - id: "c"
+        text: "The LLM hallucinated a plausible-looking field that does not actually exist"
+        isCorrect: true
+      - id: "d"
+        text: "The field exists only when MeshSync is installed separately"
+        isCorrect: false
+
+  - id: "q3"
+    text: "Which of the following approaches correctly addresses the problem of an LLM having no knowledge of your live cluster state?"
+    type: "multiple-answers"
+    marks: 2
+    explanation: "Passing relevant cluster state into the prompt and using tool-equipped agents that call kubectl or Meshery APIs at query time are both valid approaches to grounding an LLM in real system state. The model cannot access live data on its own - you must put that data in the context."
+    options:
+      - id: "a"
+        text: "Asking the LLM to predict cluster state based on your description of the system design"
+        isCorrect: false
+      - id: "b"
+        text: "Passing the output of mesheryctl system check into the prompt before asking questions about it"
+        isCorrect: true
+      - id: "c"
+        text: "Using a tool-equipped agent that calls Meshery APIs to retrieve live state at query time"
+        isCorrect: true
+      - id: "d"
+        text: "Using a model with a larger context window, which gives it access to more recent information"
+        isCorrect: false
+
+  - id: "q4"
+    text: "You are designing an automated pipeline where an LLM generates a Meshery design, and the design is applied to your production cluster immediately without human review. Which failure mode makes this architecture most risky?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Confident wrongness - the combination of hallucination and lack of internal accuracy signal - means the LLM can produce an invalid or dangerous configuration that sounds completely correct. Without a human review or programmatic validation step, that configuration goes directly to production. Human-in-the-loop is non-optional for infrastructure automation."
+    options:
+      - id: "a"
+        text: "The LLM will refuse to generate YAML for production environments"
+        isCorrect: false
+      - id: "b"
+        text: "The LLM may generate invalid or dangerous configurations with the same confident tone as correct ones"
+        isCorrect: true
+      - id: "c"
+        text: "The LLM cannot generate valid YAML without access to the Kubernetes API"
+        isCorrect: false
+      - id: "d"
+        text: "The context window will always be exceeded by production-scale manifests"
+        isCorrect: false
+
+  - id: "q5"
+    text: "What does it mean that LLM output is non-deterministic, and what is the correct mitigation for infrastructure automation?"
+    type: "short-answer"
+    marks: 2
+    correctAnswer: "Non-determinism means the model may produce different output for the same input across runs due to probabilistic token sampling. The mitigation is to use low temperature settings for structured output tasks and to validate all generated output programmatically before use rather than assuming consistency."
+    case_sensitive: false
+
+  - id: "q6"
+    text: "You need an LLM to analyze the output of mesheryctl system check and identify the root cause across several warnings, then recommend which configuration change to make. Which model tier is most appropriate and why?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Multi-step root cause reasoning across multiple signals is a reasoning task - the type where the capability gap between model tiers is most pronounced. A small model may produce plausible-sounding but incorrect reasoning, which is more dangerous than clearly wrong output. Reasoning tasks warrant a larger, higher-capability model."
+    options:
+      - id: "a"
+        text: "A small, fast model - because low latency is more important than accuracy for incident response"
+        isCorrect: false
+      - id: "b"
+        text: "A mid-tier model for classification, because the task is just categorizing warnings"
+        isCorrect: false
+      - id: "c"
+        text: "A larger, higher-capability model - because multi-step root cause reasoning is where capability gaps are most pronounced"
+        isCorrect: true
+      - id: "d"
+        text: "Model tier does not matter for this task because mesheryctl output is always structured"
+        isCorrect: false
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/prompt-engineering-for-cloud-native-operations/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/prompt-engineering-for-cloud-native-operations/_index.md
@@ -1,0 +1,16 @@
+---
+type: "course"
+id: "prompt-engineering-for-cloud-native-operations"
+title: "2. Prompt Engineering for Cloud Native Operations"
+description: "Learn how to write prompts that produce reliable, parseable output from an LLM when your inputs are real infrastructure state and your outputs drive real changes to a Kubernetes cluster."
+weight: 2
+tags: ["ai", "prompting"]
+categories: "AI"
+level: "beginner"
+---
+
+A prompt is not a search query. When you attach an LLM to a live Kubernetes cluster through Meshery, the quality of your prompts determines whether the agent converges on a safe, correct action or drifts into hallucinated resource names and fabricated flags. This course treats prompt engineering as an operational discipline with the same rigor you would apply to any other systems interface.
+
+You will move through five tightly scoped lessons: defining the role split between system and user instructions, grounding every prompt in real cluster state from `kubectl` or MeshSync, coercing the model into machine-readable YAML and JSON, reusing proven prompt patterns for common ops tasks, and building a small eval set so you catch regressions before they reach production.
+
+Each lesson is written for platform and infrastructure engineers who already have a Meshery environment running. The goal is not to produce clever prompts - it is to produce predictable ones that a coding agent can execute safely, repeatedly, and without manual correction.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/prompt-engineering-for-cloud-native-operations/prompting/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/prompt-engineering-for-cloud-native-operations/prompting/_index.md
@@ -1,0 +1,10 @@
+---
+type: "module"
+id: "prompting"
+title: "Prompting"
+description: "Practical prompt engineering techniques for platform engineers operating cloud native infrastructure through LLMs and coding agents."
+weight: 1
+tags: ["prompting"]
+categories: "AI"
+level: "beginner"
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/prompt-engineering-for-cloud-native-operations/prompting/evaluating-your-prompts/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/prompt-engineering-for-cloud-native-operations/prompting/evaluating-your-prompts/_index.md
@@ -1,0 +1,139 @@
+---
+type: "page"
+id: "evaluating-your-prompts"
+title: "Evaluating Your Prompts"
+description: "Build a small eval set before scaling your prompts, use golden examples to catch regressions, and detect when a prompt or model change breaks expected behavior."
+weight: 5
+---
+
+A prompt that works once in an interactive session is not a prompt you can trust in an automated pipeline. Models change. Context changes. The same prompt that produced a correct HPA manifest last week might produce one with a subtly wrong `scaleTargetRef` today if the underlying model was updated. Evaluation is how you detect these regressions before they reach your cluster.
+
+Prompt evaluation does not require a sophisticated platform. A small, well-chosen set of test cases run consistently is worth more than an elaborate framework run inconsistently.
+
+## What an Eval Set Is
+
+An eval set is a collection of (input, expected output) pairs that you run against your prompt to verify it still behaves correctly. Each pair is called an **eval case**.
+
+For infrastructure prompts, an eval case typically contains:
+
+- **Input context** - the grounded state you would pass to the model (kubectl output, design YAML, etc.)
+- **Task instruction** - the user turn prompt
+- **Expected output** - a "golden" example of what a correct response looks like
+- **Pass criteria** - how you determine whether the actual output matches the expected output
+
+## Building Your First Eval Set
+
+Start small. Three to five eval cases cover the most important behaviors. You can expand the set as you discover edge cases.
+
+### Step 1: Identify the High-Value Cases
+
+For each prompt in your agentic workflow, ask:
+- What is the most common input this prompt will receive?
+- What inputs are structurally different but equally valid? (e.g., single-container vs. multi-container pods)
+- What inputs have historically caused problems? (e.g., deployments without resource limits)
+- What is the minimum correct output? (e.g., valid YAML with required fields)
+
+A good starting eval set for a "generate HPA manifest" prompt might include:
+1. A simple single-container deployment
+2. A deployment that already has an HPA (expect the prompt to output a diff, not a duplicate)
+3. A deployment with no resource limits (expect the prompt to flag this rather than guess at CPU targets)
+
+### Step 2: Capture Golden Examples
+
+A golden example is a manually verified output for a specific input. It is the reference answer.
+
+Capture golden examples while you are still in the interactive prompt development phase. When the model produces a response that is exactly correct, save it as a golden example for that input. Do not rely on memory or informal approval - write the golden to a file.
+
+```bash
+# Directory structure for eval cases
+prompts/
+  generate-hpa/
+    eval-01-simple-deployment/
+      input.yaml         # kubectl get deployment output
+      task.txt           # the user turn prompt
+      golden.yaml        # expected output YAML
+    eval-02-existing-hpa/
+      input.yaml
+      task.txt
+      golden.yaml
+    eval-03-missing-limits/
+      input.yaml
+      task.txt
+      golden.txt         # expected: an error or refusal, not a manifest
+```
+
+### Step 3: Define Pass Criteria
+
+Exact string matching rarely works for LLM outputs. Define what "correct" means for your use case:
+
+| Criteria type | When to use | Example |
+|---|---|---|
+| Exact match | Short, deterministic outputs | A specific command string |
+| Structural match | YAML/JSON with required fields | All required Kubernetes fields present |
+| Schema validation | Kubernetes manifests | `kubectl apply --dry-run=server` passes |
+| Semantic match | Natural language in the output | Key phrase is present |
+| Absence check | The model should refuse | No manifest produced when state is missing |
+
+For most infrastructure prompts, a combination of schema validation (does it apply cleanly?) and structural match (are the required fields set to the expected values?) is sufficient.
+
+## Running Evals
+
+A minimal eval runner for infrastructure prompts is a shell script that calls your LLM via its API, applies the output to a test cluster with `--dry-run=server`, and compares specific fields:
+
+```bash
+#!/usr/bin/env bash
+# eval-run.sh - run a single eval case
+
+CASE_DIR="$1"
+INPUT=$(cat "$CASE_DIR/input.yaml")
+TASK=$(cat "$CASE_DIR/task.txt")
+
+# Call your LLM (replace with your actual API wrapper)
+OUTPUT=$(call_llm --system "$(cat prompts/system.txt)" --user "$TASK\n\nState:\n$INPUT")
+
+# Validate the output applies cleanly
+echo "$OUTPUT" | kubectl apply --dry-run=server -f - 2>&1
+DRY_RUN_EXIT=$?
+
+if [ $DRY_RUN_EXIT -ne 0 ]; then
+  echo "FAIL: dry-run validation failed"
+  exit 1
+fi
+
+# Check a required field
+ACTUAL_MAX=$(echo "$OUTPUT" | yq '.spec.maxReplicas')
+EXPECTED_MAX=$(cat "$CASE_DIR/golden.yaml" | yq '.spec.maxReplicas')
+
+if [ "$ACTUAL_MAX" = "$EXPECTED_MAX" ]; then
+  echo "PASS"
+else
+  echo "FAIL: maxReplicas expected $EXPECTED_MAX, got $ACTUAL_MAX"
+fi
+```
+
+This is a starting point, not a production-grade framework. The critical habit is running it.
+
+## Detecting Regressions
+
+Run your eval set whenever:
+
+- You change the system prompt
+- You change the model or model version
+- You add a new use case to an existing prompt
+- A user reports that the prompt produced unexpected output
+
+The eval set catches regressions. Without it, you will not know that a system prompt edit that fixed one case silently broke another.
+
+## Scaling the Eval Set
+
+As you accumulate more eval cases, patterns emerge. Edge cases that caused failures become new golden examples. Over time, your eval set documents the behavior contract of your prompt - what it should do and what it should refuse to do.
+
+Before scaling an agentic workflow from development to production, verify that:
+
+- [ ] You have at least three eval cases covering the main input variations
+- [ ] All eval cases pass against the current prompt and model
+- [ ] At least one eval case covers a refusal scenario (model should not produce output)
+- [ ] Evals are stored in version control alongside the prompt definition
+- [ ] There is a process to run evals before any prompt or model change is deployed
+
+Evaluation is not overhead - it is the mechanism that makes prompt-driven infrastructure automation trustworthy enough to run without a human reviewing every output.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/prompt-engineering-for-cloud-native-operations/prompting/grounding-prompts-in-infra-state/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/prompt-engineering-for-cloud-native-operations/prompting/grounding-prompts-in-infra-state/_index.md
@@ -1,0 +1,124 @@
+---
+type: "page"
+id: "grounding-prompts-in-infra-state"
+title: "Grounding Prompts in Infrastructure State"
+description: "Learn to feed real kubectl and MeshSync output into prompts so your LLM reasons from actual cluster state rather than stale assumptions."
+weight: 2
+---
+
+An LLM has no direct connection to your cluster. It cannot `kubectl get pods` on its own. Everything it knows about your infrastructure during a prompt session comes from what you put in the context window. If you put nothing in, it reasons from training data - which may be months old, tuned on different cluster configurations, and completely wrong about your specific environment.
+
+Grounding means feeding real, current state into the prompt before asking the model to reason or act. It is the difference between a useful answer and a confident hallucination.
+
+## Why Stale Assumptions Are Dangerous
+
+Consider asking an LLM to "optimize my resource requests for the `api-gateway` deployment." Without real state, the model will:
+
+1. Invent plausible-looking CPU and memory values
+2. Assume a resource version or API group that may not match your cluster
+3. Reference labels and selectors it cannot know
+4. Produce a manifest that looks correct but will fail on apply
+
+With real state, the model has the actual `.spec`, the actual resource requests currently set, the actual label selectors, and the actual API version. The diff between its output and your current state is small and reviewable.
+
+## Sources of Real Infrastructure State
+
+### kubectl Output
+
+`kubectl` is the most direct source of live cluster state. Pipe its output into your prompt:
+
+```bash
+kubectl get deployment api-gateway -n production -o yaml
+```
+
+```bash
+kubectl get pods -n production -l app=api-gateway \
+  --output=jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\n"}{end}'
+```
+
+```bash
+kubectl top pods -n production --sort-by=memory
+```
+
+Paste the output directly into the user turn of your prompt, clearly labeled:
+
+```text
+Current deployment state (kubectl get deployment api-gateway -n production -o yaml):
+<paste output here>
+
+Task: Adjust resource requests so that CPU request is 50% of the current limit.
+Output only the modified deployment YAML.
+```
+
+### mesheryctl and MeshSync
+
+Meshery's MeshSync component continuously reconciles cluster state and stores it in Meshery's graph. You can query that state with `mesheryctl`:
+
+```bash
+mesheryctl system check
+```
+
+For designs, the Meshery Catalog and imported designs give you a versioned snapshot of intended state:
+
+```bash
+mesheryctl design import -f designs/microservices-demo.yaml -s "Kubernetes Manifest"
+```
+
+When you have imported a design, you can reference its components by name in your prompts. The LLM can then reason over the declared design alongside the observed state from MeshSync, and identify drift.
+
+### Combining Observed and Declared State
+
+The most powerful grounding pattern is to provide both what your cluster declares (the design) and what it actually runs (live kubectl output), then ask the LLM to identify and reconcile differences:
+
+```text
+System:
+You are an infrastructure drift analyzer. Given declared design state and observed live state,
+identify discrepancies and output a minimal YAML patch to bring live state into alignment
+with declared state. Output only valid YAML in a ```yaml block.
+
+User:
+Declared design (Meshery design import output):
+<paste design YAML>
+
+Observed state (kubectl get deployment -n staging -o yaml):
+<paste kubectl output>
+
+Task: Identify fields that differ between declared and observed. Output a strategic merge patch
+that, when applied with `kubectl patch`, would align observed state with declared state.
+```
+
+## Retrieval Over Recall
+
+The principle here is simple: **always retrieve before you reason**. Do not ask the model to recall what your cluster looks like. Retrieve the actual state with a tool call or shell command, and inject it into the prompt.
+
+This is the same principle behind Retrieval-Augmented Generation (RAG): instead of relying on what the model learned during training, you fetch the current, authoritative source at inference time and give it directly to the model.
+
+For infrastructure operations, the retrieval step should be automated wherever possible. A coding agent that operates on your cluster should:
+
+1. Run `kubectl get <resource> -o yaml` before every modify operation
+2. Pass the result into the next LLM turn as context
+3. Never proceed with a modify prompt unless the current state was fetched in the same session
+
+## Sizing Context Inputs
+
+Context windows have limits. A full `kubectl get all -A -o yaml` for a large cluster can easily exceed what a model can reason over effectively. Be precise:
+
+| Instead of | Use |
+|---|---|
+| `kubectl get all -A -o yaml` | `kubectl get deployment api-gateway -n production -o yaml` |
+| Full node describe output | `kubectl describe node <name> | grep -A5 "Allocatable"` |
+| All pod logs | `kubectl logs <pod> --tail=50` |
+
+Narrow inputs produce better outputs. Give the model exactly the state it needs to answer the question, and nothing more.
+
+## Grounding Checklist
+
+Before sending any infrastructure-change prompt:
+
+- [ ] Have you fetched current state from the cluster in this session?
+- [ ] Is the fetched state included in the user turn, clearly labeled?
+- [ ] Have you scoped the kubectl query to the specific resource and namespace?
+- [ ] If comparing design to live state, are both provided?
+- [ ] Does your system prompt instruct the model to refuse ungrounded requests?
+
+Grounding is not optional when the LLM's output will be applied to real infrastructure. Make it a non-negotiable step in every agentic workflow you build.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/prompt-engineering-for-cloud-native-operations/prompting/prompt-patterns-for-ops/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/prompt-engineering-for-cloud-native-operations/prompting/prompt-patterns-for-ops/_index.md
@@ -1,0 +1,177 @@
+---
+type: "page"
+id: "prompt-patterns-for-ops"
+title: "Prompt Patterns for Operations"
+description: "Apply proven prompt patterns - few-shot, checklist, step-by-step decomposition, and role prompting - to recurring cloud native operations tasks."
+weight: 4
+---
+
+Prompt patterns are reusable structures that reliably produce a certain class of output. Rather than writing every prompt from scratch, you build a library of patterns suited to your operations domain and instantiate them for each specific task. This lesson covers the four patterns most useful for cloud native operations and shows how each maps to real Meshery and Kubernetes workflows.
+
+## Pattern 1: Few-Shot Prompting
+
+Few-shot prompting provides the model with two or three complete examples of input-output pairs before presenting the actual task. The examples calibrate the model's output structure, tone, and precision without requiring an explicit schema.
+
+### When to Use It
+
+Use few-shot prompting when:
+- Your output format is complex or organization-specific (custom annotation schemes, non-standard label sets)
+- You want the model to match an existing pattern in your codebase or design catalog
+- Zero-shot prompting is producing structurally inconsistent results
+
+### Example: Generating HPA Manifests from Specs
+
+```text
+Example 1:
+Input: service=checkout, namespace=payments, min=2, max=8, cpu_target=65
+Output:
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: checkout-hpa
+  namespace: payments
+  labels:
+    team: payments
+    managed-by: meshery
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: checkout
+  minReplicas: 2
+  maxReplicas: 8
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 65
+
+Example 2:
+Input: service=catalog, namespace=commerce, min=1, max=5, cpu_target=70
+Output:
+[... second example ...]
+
+Now produce for:
+Input: service=inventory, namespace=commerce, min=3, max=12, cpu_target=60
+```
+
+The model learns from the examples that it should include the `team` and `managed-by` labels - conventions that would require verbose instructions to describe explicitly.
+
+## Pattern 2: Checklist Prompting
+
+Checklist prompting asks the model to verify a list of conditions before producing output, or to produce output that satisfies a specific checklist. It is the prompt equivalent of a pre-flight check.
+
+### When to Use It
+
+Use checklist prompting for:
+- Pre-deploy validation (does this manifest satisfy our baseline standards?)
+- Security reviews (does this service account request minimal permissions?)
+- Drift detection (does observed state match declared state on these specific fields?)
+
+### Example: Manifest Security Review
+
+```text
+Review the following Kubernetes Deployment manifest against this security checklist.
+For each item, output a line with the item text, then PASS or FAIL, then a one-line reason.
+
+Checklist:
+1. Container does not run as root (runAsNonRoot: true or runAsUser > 0)
+2. Container image is not tagged :latest
+3. readOnlyRootFilesystem is set to true
+4. No hostPid, hostNetwork, or hostIPC is set to true
+5. Resource requests and limits are both set for CPU and memory
+
+Manifest:
+<paste manifest>
+```
+
+This pattern produces output that is easy to parse and easy to audit. It also makes the model's reasoning transparent - you can see exactly which checks failed and why.
+
+## Pattern 3: Step-by-Step Decomposition
+
+Complex operations tasks are too large to accomplish in a single LLM turn. Step-by-step decomposition breaks a high-level goal into an ordered sequence of concrete steps, where each step is small enough for the model to handle accurately.
+
+### When to Use It
+
+Use decomposition when:
+- The task involves multiple resources or multiple namespaces
+- The task has ordering constraints (create ConfigMap before Deployment)
+- You want a human review point between steps
+- The task involves both reading state and writing new configuration
+
+### Example: Migrating a Workload to a New Namespace
+
+```text
+I need to migrate the `api-gateway` workload from the `staging` namespace to the `production` namespace.
+
+Break this into an ordered list of steps. For each step, provide:
+- Step number and name
+- The exact kubectl or mesheryctl command to run
+- What to verify after running it before proceeding to the next step
+
+Constraints:
+- Do not delete the staging namespace resources until production is confirmed healthy
+- Preserve all existing labels and annotations
+- The Meshery design for this workload is in designs/microservices-demo.yaml
+```
+
+The decomposed output becomes a runnable procedure. A coding agent can execute each step, capture the verification output, and gate on it before proceeding - providing natural human-in-the-loop checkpoints.
+
+## Pattern 4: Role Prompting
+
+Role prompting assigns the model a specific expert persona that shapes how it reasons and what it emphasizes. For infrastructure operations, roles like "senior SRE", "security reviewer", or "cost optimization analyst" produce noticeably different outputs from the same input.
+
+### When to Use It
+
+Use role prompting when:
+- You want a specific analytical lens applied to the same input (security vs. reliability vs. cost)
+- You want the model to reason in a domain with established conventions (SRE, FinOps)
+- You want the model to challenge a configuration rather than just describe it
+
+### Example: Reliability Review
+
+```text
+System:
+You are a senior site reliability engineer reviewing Kubernetes configurations for
+production readiness. You are skeptical of any configuration that lacks explicit
+resource limits, missing liveness/readiness probes, or single-replica deployments.
+You output findings in order of severity: Critical, High, Medium, Low.
+
+User:
+Review this deployment for production readiness:
+<paste deployment YAML>
+```
+
+The role shapes the model's focus. Without the SRE persona, the same prompt might produce a neutral description of the manifest. With it, you get an opinionated, prioritized findings list that is actionable.
+
+## Combining Patterns
+
+These patterns compose. A production-readiness pipeline might use:
+
+1. **Role prompting** in the system prompt (senior SRE)
+2. **Grounding** in the user turn (live kubectl output + designs/observability-stack.yaml)
+3. **Checklist prompting** to structure the review
+4. **Step-by-step decomposition** to produce a remediation plan
+
+```text
+System:
+You are a senior SRE. Review configurations for reliability, not for style.
+
+User:
+Checklist for this deployment review:
+1. Single points of failure (replicas < 2)
+2. Missing resource limits
+3. Missing health probes
+4. No PodDisruptionBudget
+5. No NetworkPolicy
+
+Current state:
+<kubectl output>
+
+After the checklist, produce a step-by-step remediation plan with the exact manifests
+to apply for any FAIL items.
+```
+
+Combining patterns does not add complexity - it reduces ambiguity. Each pattern constrains a different dimension of the model's output, and together they narrow the space of acceptable responses to exactly what your agentic pipeline needs.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/prompt-engineering-for-cloud-native-operations/prompting/quiz.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/prompt-engineering-for-cloud-native-operations/prompting/quiz.md
@@ -1,0 +1,81 @@
+---
+title: "Module Quiz"
+passPercentage: 70
+type: "test"
+questions:
+  - id: "q1"
+    text: "Which location is most appropriate for defining an agent's authorization scope and output format requirements?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Authorization scope and output format apply to every interaction the agent has. These constraints belong in the system prompt, which runs before any user turn and cannot be overridden by a user message. Placing them in the user turn means a future user turn can accidentally override them."
+    options:
+      - id: "a"
+        text: "The user turn, so the operator can adjust them per request"
+        isCorrect: false
+      - id: "b"
+        text: "The system prompt, so they apply to every interaction"
+        isCorrect: true
+      - id: "c"
+        text: "A separate configuration file read by the agent at runtime"
+        isCorrect: false
+      - id: "d"
+        text: "A comment at the top of the YAML manifest the agent produces"
+        isCorrect: false
+
+  - id: "q2"
+    text: "What is the primary reason to pass kubectl output into a prompt before asking the LLM to modify a Kubernetes resource?"
+    type: "single-answer"
+    marks: 2
+    explanation: "An LLM has no live connection to a cluster. Without real state passed in the context window, the model reasons from training data that may be months old and specific to different cluster configurations. Grounding with real kubectl output ensures the model reasons from actual current state rather than stale or fabricated assumptions."
+    options:
+      - id: "a"
+        text: "To reduce the number of tokens used in the prompt"
+        isCorrect: false
+      - id: "b"
+        text: "To ensure the model reasons from actual current cluster state rather than stale training data"
+        isCorrect: true
+      - id: "c"
+        text: "To satisfy a Meshery API requirement before running mesheryctl"
+        isCorrect: false
+      - id: "d"
+        text: "To give the model access to the cluster credentials"
+        isCorrect: false
+
+  - id: "q3"
+    text: "Which of the following techniques for getting reliable YAML output from an LLM involves providing two or three complete examples of correctly formatted manifests before stating the actual task?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Few-shot prompting provides the model with complete input-output examples before the actual task. The examples calibrate the model's output structure - including organization-specific labels and annotations - without requiring verbose schema descriptions. A skeleton with placeholders is a different structural technique, and role prompting assigns an expert persona."
+    options:
+      - id: "a"
+        text: "Role prompting"
+        isCorrect: false
+      - id: "b"
+        text: "Checklist prompting"
+        isCorrect: false
+      - id: "c"
+        text: "Few-shot prompting"
+        isCorrect: true
+      - id: "d"
+        text: "Skeleton with placeholders"
+        isCorrect: false
+
+  - id: "q4"
+    text: "Before scaling a prompt-driven agentic workflow to production, which of the following should be true about your eval set? Select all that apply."
+    type: "multiple-answers"
+    marks: 2
+    explanation: "A production-ready eval set should cover the main input variations (at least three cases), include at least one refusal scenario to verify the model correctly declines ungrounded or out-of-scope requests, and be stored in version control alongside the prompt so changes to either are tracked together. Running evals on every model update is also required to catch regressions from model changes."
+    options:
+      - id: "a"
+        text: "At least three eval cases covering the main input variations"
+        isCorrect: true
+      - id: "b"
+        text: "At least one eval case covering a refusal scenario"
+        isCorrect: true
+      - id: "c"
+        text: "Eval cases stored in version control alongside the prompt definition"
+        isCorrect: true
+      - id: "d"
+        text: "All eval cases must use exact string matching to verify output"
+        isCorrect: false
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/prompt-engineering-for-cloud-native-operations/prompting/structured-output-yaml-and-json/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/prompt-engineering-for-cloud-native-operations/prompting/structured-output-yaml-and-json/_index.md
@@ -1,0 +1,161 @@
+---
+type: "page"
+id: "structured-output-yaml-and-json"
+title: "Structured Output: YAML and JSON"
+description: "Techniques for reliably coercing an LLM into producing valid, parseable YAML or JSON that a coding agent can apply directly to your cluster."
+weight: 3
+---
+
+The value of an LLM in an infrastructure workflow is realized only when its output can be consumed by the next step in the pipeline - `kubectl apply`, a Meshery design import, or a configuration management tool. That requires the output to be machine-readable every time, not just most of the time.
+
+LLMs are trained to be helpful and conversational. Left unconstrained, they will mix prose and YAML in the same response, add "Here is the manifest:" headers inside code blocks, or produce YAML that is subtly malformed due to incorrect indentation. This lesson covers the techniques that reliably produce clean, parseable output.
+
+## The Core Instruction: Output Only YAML
+
+The most effective single instruction for structured output is to tell the model to output only the target format, with no surrounding text:
+
+```text
+Output only valid YAML. Do not include any explanatory text, comments, or prose.
+Do not include the ```yaml fence markers - output raw YAML only.
+```
+
+Or, if your parser expects fenced blocks:
+
+```text
+Output exactly one ```yaml code block containing the manifest. Do not include any text
+outside that code block, before or after it.
+```
+
+Choose one convention and enforce it in your system prompt. Your parsing code should enforce the same convention on the receiving end.
+
+## Providing a Schema or Example
+
+An LLM that has been shown the exact structure it should produce is significantly more reliable than one working from a verbal description. For Kubernetes manifests, use the official API structure as your schema anchor.
+
+### Technique 1: Skeleton with Placeholders
+
+Provide the structure with placeholders for the values the model should fill in:
+
+```text
+Produce a Kubernetes ConfigMap with the following structure, filling in ONLY the
+placeholders marked with <angle brackets>. Do not add or remove any fields.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <name>
+  namespace: <namespace>
+  labels:
+    app: <app-label>
+data:
+  <key>: <value>
+```
+```
+
+### Technique 2: Golden Example
+
+Provide a complete example of a correctly formed output and ask the model to produce one in the same structure for the new inputs:
+
+```text
+Produce a HorizontalPodAutoscaler using exactly this structure:
+
+```yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: api-gateway-hpa
+  namespace: production
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: api-gateway
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 60
+```
+
+Now produce the same for: deployment `payment-service`, namespace `production`,
+minReplicas 3, maxReplicas 8, target CPU utilization 70%.
+```
+
+Golden examples are especially powerful when your environment uses custom annotations, non-standard label schemes, or organization-specific conventions that a model will not produce correctly from first principles.
+
+## JSON for Programmatic Workflows
+
+When a coding agent needs to parse the model's output in code, JSON is often easier to handle than YAML because every major language has a strict JSON parser and YAML parsers vary in their tolerance for edge cases.
+
+```text
+Output a JSON object with the following schema. Output only the JSON object, with no
+surrounding text or markdown fences.
+
+Schema:
+{
+  "action": "apply" | "delete" | "patch",
+  "resource_kind": string,
+  "resource_name": string,
+  "namespace": string,
+  "manifest": object
+}
+```
+
+For Meshery design imports, YAML is the expected format. Use JSON only when your tooling downstream expects it - for example, when writing a webhook handler or a validation step in your agentic pipeline.
+
+## Validating the Result
+
+Producing structured output from an LLM is not a guarantee of correctness - it is a constraint on format. You still need to validate the result before applying it.
+
+### Syntactic Validation
+
+For YAML, use `yq` or a similar tool to confirm the output parses:
+
+```bash
+echo "$LLM_OUTPUT" | yq '.' > /dev/null && echo "valid" || echo "invalid"
+```
+
+For JSON:
+
+```bash
+echo "$LLM_OUTPUT" | python3 -m json.tool > /dev/null && echo "valid" || echo "invalid"
+```
+
+### Schema Validation
+
+For Kubernetes manifests, validate against the cluster's API using a dry run:
+
+```bash
+kubectl apply --dry-run=server -f - <<EOF
+$LLM_OUTPUT
+EOF
+```
+
+The server-side dry run validates the manifest against the cluster's API schema, including CRDs, without making any actual changes. This is the correct validation step before applying any LLM-generated manifest.
+
+### Integration with Meshery
+
+Meshery's design validation checks a design against the component registry before import. After generating a manifest, import it as a design and let Meshery's registry validate component types, relationships, and constraints:
+
+```bash
+mesheryctl design import -f generated-manifest.yaml -s "Kubernetes Manifest"
+```
+
+If the design fails validation, the error message gives you the specific field or component type that is wrong - feed that error back into the LLM as a correction turn rather than attempting to fix it manually.
+
+## Common Failure Modes
+
+| Failure | Cause | Fix |
+|---|---|---|
+| Prose mixed into YAML | No output format in system prompt | Add "output only YAML" to system prompt |
+| Wrong indentation | Model uses 4-space indent | Add "use 2-space YAML indentation" to instructions |
+| Missing required fields | Model omits fields it considers optional | Provide schema or skeleton with all required fields |
+| Wrong API version | Model uses outdated training data | Include target API version in the user turn explicitly |
+| Extra comments in YAML | Model is being "helpful" | Add "do not include YAML comments" to instructions |
+
+Structured output is reliable when your prompts are specific about format and your pipeline validates before acting. Never apply LLM-generated manifests directly to a production cluster without a dry-run validation step.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/prompt-engineering-for-cloud-native-operations/prompting/system-and-user-instructions/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/prompt-engineering-for-cloud-native-operations/prompting/system-and-user-instructions/_index.md
@@ -1,0 +1,86 @@
+---
+type: "page"
+id: "system-and-user-instructions"
+title: "System and User Instructions"
+description: "Understand the role split between system and user instructions and learn to write prompts that give an LLM clear task scope, firm constraints, and an unambiguous output contract."
+weight: 1
+---
+
+Every LLM conversation has at least two instruction channels: the **system prompt** and the **user turn**. Getting this split right is the single most impactful thing you can do before optimizing any other aspect of your prompts for cloud native operations.
+
+## The Two Roles
+
+### System Instructions
+
+The system prompt runs before any user message and is not visible to end users in most deployments. Think of it as the operator's brief to the LLM - it sets identity, scope, and non-negotiable constraints.
+
+For infrastructure operations, system instructions should cover:
+
+- **Identity and scope** - what the agent is and what it is authorized to do. Example: "You are an infrastructure assistant for a Kubernetes platform team. You may suggest configuration changes, but you must never suggest deleting a namespace unless the user explicitly provides the namespace name and confirms deletion."
+- **Output contract** - what format every response must follow. Example: "All responses that include Kubernetes configuration must be valid YAML fenced in a ```yaml block. Do not include explanatory prose inside the YAML block."
+- **Grounding rules** - what the agent should refuse to do without real data. Example: "Do not make assumptions about running workloads. If the user has not provided `kubectl get` output or MeshSync state, ask for it before proceeding."
+- **Persona constraints** - tone, verbosity, and what the agent should decline. Terse, tool-oriented responses are more useful to an operator than conversational ones.
+
+### User Instructions
+
+The user turn is where specific tasks arrive - either from a human or from an orchestrating agent. User instructions should be specific, bounded, and include the relevant state. A vague user turn like "fix my deployment" forces the LLM to guess, and guesses produce unreliable output.
+
+A well-formed user turn has three parts:
+
+| Part | Purpose | Example |
+|---|---|---|
+| Task | What to produce | "Generate a HorizontalPodAutoscaler manifest" |
+| Constraints | Limits on the output | "Target CPU utilization: 60%. Min replicas: 2. Max replicas: 10." |
+| State context | Real data to reason over | *(paste of `kubectl get deploy -n production -o yaml`)* |
+
+## Designing Clear Instructions
+
+### Be Specific About the Task
+
+Vague: "Help me scale my app."
+
+Specific: "Write a Kubernetes HorizontalPodAutoscaler for the `api-gateway` deployment in the `production` namespace. Target CPU utilization is 60%. Minimum replicas: 2. Maximum replicas: 10."
+
+The specific version leaves no room for interpretation. The LLM does not need to ask a clarifying question - it has everything required to produce a correct manifest.
+
+### Encode Constraints Explicitly
+
+Constraints you leave out of the prompt become constraints the LLM invents - or ignores. Common constraints for infrastructure prompts:
+
+- Resource limits and requests
+- Namespaces in scope (and namespaces that are out of scope)
+- Labels and annotations that must be preserved
+- Fields that must not be changed
+- The Kubernetes API version to target
+
+### Define the Output Format in the System Prompt
+
+If your coding agent will parse the response programmatically, the output format must be non-negotiable and defined in the system prompt - not asked for in the user turn. A user turn instruction like "please output YAML" can be overridden by a long conversation; a system prompt instruction cannot.
+
+```text
+System:
+You are an infrastructure configuration assistant.
+Every response that contains Kubernetes configuration MUST be enclosed in a ```yaml code block.
+Do not include any text inside that block except valid YAML.
+If you cannot produce valid YAML for the requested task, say so in plain text outside any code block.
+```
+
+## Splitting Responsibility Between Prompts
+
+A useful mental model: the system prompt owns **what the agent is**, and the user turn owns **what the agent should do right now**. If a constraint applies to every interaction - authorization scope, output format, grounding rules - it belongs in the system prompt. If a constraint applies only to this request - the specific namespace, the specific resource count - it belongs in the user turn.
+
+Mixing these produces fragile prompts. When authorization scope is in the user turn, a future user turn can accidentally override it. When task-specific constraints are in the system prompt, they create noise and can conflict with legitimate future requests.
+
+## Practical Checklist
+
+Before sending a prompt that will drive a real infrastructure change through Meshery, verify:
+
+- [ ] System prompt defines the agent's authorization scope
+- [ ] System prompt specifies the output format
+- [ ] System prompt includes grounding rules (no assumptions without real state)
+- [ ] User turn names the specific resource, namespace, and cluster
+- [ ] User turn includes or references actual cluster state
+- [ ] User turn states constraints explicitly (limits, labels, versions)
+- [ ] There is no ambiguity about what "done" looks like
+
+Clear instructions are not just a best practice - they are a safety mechanism. An LLM that has been given precise scope and format requirements is significantly less likely to produce output that causes an unintended change to your cluster.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/prompt-engineering-for-cloud-native-operations/test.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/prompt-engineering-for-cloud-native-operations/test.md
@@ -1,0 +1,108 @@
+---
+title: "Course Test"
+passPercentage: 70
+type: "test"
+questions:
+  - id: "q1"
+    text: "A platform engineer wants every LLM response that contains Kubernetes configuration to use a specific YAML fenced code block format with no surrounding prose. Where should this output format requirement be defined?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Output format requirements that apply to every interaction belong in the system prompt. The system prompt runs before any user message and establishes non-negotiable constraints. A user turn instruction can be diluted or overridden as a conversation grows; a system prompt instruction cannot."
+    options:
+      - id: "a"
+        text: "In each user turn, reminding the model of the format for that request"
+        isCorrect: false
+      - id: "b"
+        text: "In the system prompt, so it applies to all responses without repetition"
+        isCorrect: true
+      - id: "c"
+        text: "In a post-processing script that reformats the raw model output"
+        isCorrect: false
+      - id: "d"
+        text: "In a Kubernetes ConfigMap that the agent reads before responding"
+        isCorrect: false
+
+  - id: "q2"
+    text: "An SRE asks an LLM to 'optimize the resource requests for my api-gateway deployment' without providing any cluster state. What is the most likely failure mode?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Without real cluster state in the context window, the LLM must invent plausible values. It has no knowledge of the actual resource usage, actual current requests, or the actual label selectors and API version of the specific deployment. The result is a manifest that looks syntactically correct but is fabricated - the classic hallucination risk for infrastructure prompts."
+    options:
+      - id: "a"
+        text: "The LLM will refuse to answer because the task is too vague"
+        isCorrect: false
+      - id: "b"
+        text: "The LLM will produce a manifest with fabricated resource values that do not reflect actual usage"
+        isCorrect: true
+      - id: "c"
+        text: "The LLM will call kubectl directly to fetch the current state"
+        isCorrect: false
+      - id: "d"
+        text: "The LLM will produce a manifest with no resource requests at all"
+        isCorrect: false
+
+  - id: "q3"
+    text: "Which kubectl command validates a model-generated Kubernetes manifest against the cluster API without making any changes to the cluster?"
+    type: "single-answer"
+    marks: 2
+    explanation: "kubectl apply --dry-run=server sends the manifest to the Kubernetes API server for validation against the current schema and CRDs without persisting any changes. This is the correct validation step for LLM-generated manifests before applying them. The --dry-run=client flag only validates locally against a static schema and does not catch CRD or admission webhook failures."
+    options:
+      - id: "a"
+        text: "kubectl validate -f manifest.yaml"
+        isCorrect: false
+      - id: "b"
+        text: "kubectl apply --dry-run=client -f manifest.yaml"
+        isCorrect: false
+      - id: "c"
+        text: "kubectl apply --dry-run=server -f manifest.yaml"
+        isCorrect: true
+      - id: "d"
+        text: "kubectl diff -f manifest.yaml"
+        isCorrect: false
+
+  - id: "q4"
+    text: "A team uses a custom label scheme (team, managed-by, cost-center) on all their Kubernetes resources. They want an LLM to always include these labels when generating new manifests. Which prompt technique is most effective for teaching the model this convention?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Few-shot prompting provides complete input-output examples that show the model the exact label structure in context. Because the examples are concrete, the model learns the convention by demonstration rather than description. A verbose verbal description of the label scheme is less reliable because the model must interpret and apply it; examples show exactly what the output should look like."
+    options:
+      - id: "a"
+        text: "Role prompting - assign the model the persona of a senior platform engineer"
+        isCorrect: false
+      - id: "b"
+        text: "Few-shot prompting - provide two or three example manifests with the correct labels"
+        isCorrect: true
+      - id: "c"
+        text: "Step-by-step decomposition - ask the model to add labels one at a time"
+        isCorrect: false
+      - id: "d"
+        text: "Checklist prompting - include the label requirements in a review checklist"
+        isCorrect: false
+
+  - id: "q5"
+    text: "What is the 'retrieval over recall' principle in the context of infrastructure prompting?"
+    type: "short-answer"
+    marks: 2
+    correctAnswer: "fetch current cluster state"
+    case_sensitive: false
+    explanation: "Retrieval over recall means always fetching current, authoritative state (from kubectl, MeshSync, or another live source) and injecting it into the prompt at inference time, rather than relying on what the model learned during training. Training data can be months old and specific to different environments. Retrieval ensures the model reasons from real, current state."
+
+  - id: "q6"
+    text: "Which of the following are valid reasons to run your prompt eval set? Select all that apply."
+    type: "multiple-answers"
+    marks: 2
+    explanation: "Evals should be run whenever the system prompt changes, when the model or model version changes, when a new use case is added to an existing prompt, and when a user reports unexpected output. These are all scenarios where a previously working prompt may have regressed. Running evals only on new prompts misses regressions caused by changes to existing prompts or model updates."
+    options:
+      - id: "a"
+        text: "When the system prompt is changed"
+        isCorrect: true
+      - id: "b"
+        text: "When the underlying model or model version is updated"
+        isCorrect: true
+      - id: "c"
+        text: "When a user reports that the prompt produced unexpected output"
+        isCorrect: true
+      - id: "d"
+        text: "Only when a completely new prompt is written for the first time"
+        isCorrect: false
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/retrieval-and-context-for-infrastructure/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/retrieval-and-context-for-infrastructure/_index.md
@@ -1,0 +1,18 @@
+---
+type: "course"
+id: "retrieval-and-context-for-infrastructure"
+title: "4. Retrieval & Context (RAG) for Infrastructure"
+description: "Learn how to ground infrastructure agents in current, specific state rather than stale training data by building retrieval pipelines over cluster state, Meshery data, and operational knowledge bases."
+weight: 4
+tags: ["ai", "rag"]
+categories: "AI"
+level: "intermediate"
+---
+
+An agent that can only reason over its training data is an agent that will confidently describe a cluster that no longer exists. The training cutoff is months or years in the past; your cluster changes daily. Retrieval-augmented generation (RAG) is the bridge between a model's frozen weights and the live state of your infrastructure.
+
+This course teaches you to think about context as a resource to be managed. You will learn why context windows are finite and why that constraint shapes every design decision in an agent-powered ops workflow. You will see exactly which sources of truth - `kubectl`, `mesheryctl`, MeshSync, and Meshery designs - contain the state an agent needs, and how to surface that state at query time rather than baking it into a prompt upfront.
+
+The second half of the course turns to operationalizing retrieval: building a knowledge base from runbooks, design files, and documentation; keeping it fresh as your environment evolves; and - critically - evaluating whether the agent actually does the right thing before you trust it with a production change.
+
+By the end you will have a concrete, end-to-end mental model for building agents that are grounded in the present reality of your infrastructure rather than a probabilistic average of the internet from a year ago.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/retrieval-and-context-for-infrastructure/rag/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/retrieval-and-context-for-infrastructure/rag/_index.md
@@ -1,0 +1,10 @@
+---
+type: "module"
+id: "rag"
+title: "Retrieval & Context"
+description: "How to ground infrastructure agents in live cluster state and operational knowledge rather than stale training data."
+weight: 1
+tags: ["rag"]
+categories: "AI"
+level: "intermediate"
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/retrieval-and-context-for-infrastructure/rag/building-a-knowledge-base-for-operations/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/retrieval-and-context-for-infrastructure/rag/building-a-knowledge-base-for-operations/_index.md
@@ -1,0 +1,82 @@
+---
+type: "page"
+id: "building-a-knowledge-base-for-operations"
+title: "Building a Knowledge Base for Operations"
+description: "Turn runbooks, documentation, and designs into a retrievable knowledge base that keeps agents grounded in your organization's operational standards."
+weight: 3
+---
+
+## What Goes in an Ops Knowledge Base
+
+Live cluster state tells an agent what is. A knowledge base tells it what should be and what to do when things go wrong. The two are complementary.
+
+An operations knowledge base for a Meshery-managed environment typically contains: runbooks (step-by-step procedures for rolling restarts, certificate rotation, scaling, incident response); architecture decisions (why the system is structured the way it is); Meshery designs (importable with `mesheryctl design import`); policy documents (OPA rules in human-readable form); and known failure modes with documented resolutions.
+
+The Meshery Catalog is a shared, versioned store for designs in a structured, retrievable format.
+
+## Chunking: Splitting Documents for Retrieval
+
+Retrieval works by comparing the semantic content of a query against the semantic content of stored fragments. The operative word is "fragments": you almost never retrieve whole documents, because most of a document is irrelevant to any given query.
+
+Chunking is the process of splitting documents into retrievable units. The key decisions are:
+
+**Chunk size.** Too small and a chunk loses context - a step in a runbook is meaningless without knowing what the runbook is about. Too large and retrieval returns irrelevant content alongside the relevant fragment.
+
+A practical starting point for ops content:
+- Runbook sections: one procedure per chunk, with a header that names the procedure and the service it applies to.
+- Architecture documents: one decision or one component description per chunk.
+- Designs: index at the component level - one chunk per service or resource group defined in the design.
+
+**Chunk overlap.** Including a few sentences of overlap between consecutive chunks prevents a key sentence from falling at a boundary and being split across two chunks that are retrieved separately.
+
+**Metadata.** Attach metadata to every chunk: source file, last-modified date, relevant service or namespace, tags. This metadata enables filtered retrieval - "find runbooks tagged `production` modified in the last thirty days" - which dramatically narrows the search space before semantic comparison happens.
+
+```yaml
+# Example chunk metadata schema
+chunk_id: "runbook-cert-rotation-step-3"
+source: "runbooks/certificate-rotation.md"
+last_modified: "2025-03-10"
+tags: ["certificates", "tls", "production"]
+service: "ingress"
+text: "Rotate the wildcard certificate by running..."
+```
+
+## Retrieval: Finding the Right Chunk at Query Time
+
+A retrieval system finds relevant chunks from potentially thousands of stored documents.
+
+**Embedding-based retrieval** converts the query and stored chunks into vector representations and finds chunks whose embeddings are closest in vector space. This is semantic retrieval: it finds relevant content even when exact words do not match. **Keyword retrieval** matches exact terms - faster, but misses synonyms. In practice, hybrid retrieval combining both outperforms either alone: keyword filtering narrows the candidate set, embedding search ranks within it. The top-k chunks (typically three to five) are injected into the agent's prompt alongside the query.
+
+## Keeping the Knowledge Base Fresh
+
+A knowledge base that is not maintained becomes a liability. An agent that retrieves an outdated runbook and follows it may take the wrong action with full confidence. Freshness is a correctness requirement, not a nice-to-have.
+
+Strategies for keeping retrieval content current:
+
+| Trigger | Action |
+|---|---|
+| Runbook committed to version control | Re-index the affected document automatically in CI |
+| Design updated in Meshery Catalog | Re-index the design components |
+| Incident resolved with a new root cause | Add a post-incident chunk immediately |
+| Policy document revised | Re-index and mark old version as superseded |
+
+Attach a `last_indexed` timestamp to every chunk and surface it to the agent alongside retrieved content. An agent that sees "last indexed: 14 months ago" can flag the content as potentially stale rather than acting on it blindly.
+
+For the academy's importable designs - `designs/microservices-demo.yaml`, `designs/observability-stack.yaml`, `designs/llm-mcp-gateway.yaml`, `designs/policy-guardrails.yaml` - treat the version-controlled file as the source of truth. Any time a design is updated and re-imported with `mesheryctl design import`, re-index the corresponding knowledge base entries.
+
+## What the Agent Does with Retrieved Content
+
+The agent receives retrieved chunks as additional context before generating a response:
+
+```text
+[Retrieved - certificate rotation runbook, last indexed 2025-03-10]
+Step 3: Rotate the wildcard cert:
+  kubectl create secret tls wildcard-cert --cert=cert.pem --key=key.pem \
+    -n ingress-nginx --dry-run=client -o yaml | kubectl apply -f -
+Verify the new certificate is active before deleting the old secret.
+[End retrieved context]
+
+User query: How do I rotate the TLS certificate for the ingress controller?
+```
+
+The agent can now cite the runbook, use the exact command, and include the verification step - none of which it could produce reliably from training data alone.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/retrieval-and-context-for-infrastructure/rag/evaluating-infrastructure-agents/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/retrieval-and-context-for-infrastructure/rag/evaluating-infrastructure-agents/_index.md
@@ -1,0 +1,79 @@
+---
+type: "page"
+id: "evaluating-infrastructure-agents"
+title: "Evaluating Infrastructure Agents"
+description: "Design golden task sets, build a lightweight eval harness, and apply safety checks to determine whether an agent is trustworthy enough for real infrastructure changes."
+weight: 4
+---
+
+## Why Evaluation Is Not Optional
+
+An agent that answers quickly and confidently is not necessarily an agent that answers correctly. In infrastructure operations, the gap between those two things causes outages. Evaluation - systematically testing whether an agent does the right thing - is the discipline that closes that gap before the agent touches production. You are not checking whether code compiles; you are checking whether a system that combines an LLM, a retrieval pipeline, and tools produces correct, safe behavior across a representative range of real tasks.
+
+## Golden Tasks: The Eval Dataset
+
+A golden task is a specific, representative scenario paired with one or more acceptable answers. Building a golden task set is the first step in any eval program.
+
+### What makes a good golden task
+
+- It is grounded in something your team actually does. Do not invent fictional scenarios.
+- It has a deterministic or near-deterministic correct answer. "List all deployments in the production namespace with fewer than 2 ready replicas" has a correct answer given a known cluster state. "Improve this deployment" does not.
+- It covers the edge cases and failure modes you care most about. A golden set skewed toward happy-path tasks will miss the bugs that cause incidents.
+
+### Example golden tasks for a Meshery environment
+
+| Task | Expected behavior |
+|---|---|
+| "What namespaces are currently running in the cluster?" | Agent calls `kubectl get namespaces`, returns accurate list |
+| "Import the observability stack design" | Agent runs `mesheryctl design import -f designs/observability-stack.yaml -s "Kubernetes Manifest"` with no invented flags |
+| "Are there any pods in CrashLoopBackOff?" | Agent queries pod status, returns specific pod names and namespaces |
+| "What does the microservices-demo design define?" | Agent retrieves and summarizes the design correctly |
+| "Scale the payment service to 3 replicas" | Agent proposes the correct `kubectl scale` command and requests human approval before executing |
+
+The fifth task is especially important: it tests whether the agent respects the human-in-the-loop boundary before taking a write action.
+
+## Building an Eval Harness
+
+An eval harness runs golden tasks automatically and scores the results. A minimal harness has three components.
+
+**Fixture state** - the harness needs a reproducible cluster state: a `kind` or `k3d` cluster with known resources, a Meshery environment pre-loaded with the relevant designs, or mocked API responses. If cluster state varies between runs, scores vary for reasons unrelated to agent quality.
+
+**Task runner** - sends each golden task to the agent, captures the full output including tool calls and intermediate steps, and stores it alongside expected behavior.
+
+```bash
+#!/usr/bin/env bash
+for task_file in eval/tasks/*.yaml; do
+  task_id=$(yq '.id' "$task_file")
+  task_prompt=$(yq '.prompt' "$task_file")
+  actual=$(agent-cli run --prompt "$task_prompt" --output json)
+  echo "$task_id: $(echo $actual | jq '.tool_call')"
+done
+```
+
+**Scoring** - four dimensions matter:
+- **Tool call accuracy** - right tool, right arguments. Binary and automatable.
+- **Output correctness** - factually correct given retrieved context. Requires a reference answer or a secondary LLM judge.
+- **Safety compliance** - did the agent request approval before any write? Binary and automatable.
+- **Retrieval quality** - were the relevant chunks retrieved? Track chunk IDs against the expected set.
+
+Run the harness on every change to the system prompt, retrieval pipeline, or tool definitions. A regression in safety or tool-call accuracy is a blocking issue.
+
+## Safety Checks Before Real Changes
+
+Even a well-evaluated agent must not execute write operations without a safety gate.
+
+**Require explicit human approval for all write operations.** The agent proposes; a human approves. No `kubectl apply`, `mesheryctl design apply`, or `kubectl delete` executes without a logged approval.
+
+**Dry-run first.** Before any change, produce and surface the dry-run output:
+
+```bash
+kubectl apply -f deployment.yaml --dry-run=client -o yaml
+```
+
+**Check policy guardrails.** Evaluate the proposed change against OPA policies or Meshery constraints (loaded via `designs/policy-guardrails.yaml`) before proposing it. **Bound the blast radius** - scope agent permissions to the minimum namespace required for the task.
+
+## When to Trust an Agent with Real Changes
+
+Trust is earned through demonstrated eval performance. A reasonable threshold: tool call accuracy above 95%; zero safety violations across all eval runs; no hallucinated resource names in the last 50 tasks; retrieval quality above 90%.
+
+Start with read-only tasks in production. Expand to write operations only after sustained accuracy on reads. Treat every new write category as a new eval surface. Evaluation is not a one-time gate - it is an ongoing practice.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/retrieval-and-context-for-infrastructure/rag/grounding-agents-in-cluster-and-meshery-state/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/retrieval-and-context-for-infrastructure/rag/grounding-agents-in-cluster-and-meshery-state/_index.md
@@ -1,0 +1,83 @@
+---
+type: "page"
+id: "grounding-agents-in-cluster-and-meshery-state"
+title: "Grounding Agents in Cluster and Meshery State"
+description: "Identify the authoritative sources of infrastructure state and learn how to surface them to an agent at query time."
+weight: 2
+---
+
+## Sources of Truth in a Meshery Environment
+
+An agent making decisions about your cluster needs authoritative data, not cached assumptions. In a Meshery-managed environment, there are four primary sources of truth, each with different freshness characteristics and different strengths.
+
+### `kubectl` - Direct Kubernetes API
+
+The Kubernetes API server is the authoritative record of cluster state. `kubectl` queries it synchronously and returns current data.
+
+```bash
+# List all deployments across all namespaces
+kubectl get deployments --all-namespaces -o json
+
+# Get pod status with conditions
+kubectl get pods -n production -o yaml
+
+# Describe a failing pod to retrieve events
+kubectl describe pod <pod-name> -n production
+```
+
+An agent can invoke `kubectl` as a tool call and receive structured JSON or YAML output. This output can be parsed, filtered, and injected into the context window. The key discipline is filtering before injection: a `kubectl get pods --all-namespaces -o json` output for a large cluster may be tens of thousands of tokens. Pass only the fields the agent needs.
+
+### `mesheryctl` - Meshery Control Plane
+
+`mesheryctl` gives you access to the Meshery control plane state: registered models, active connections, designs, performance profiles, and environments.
+
+```bash
+# Check system health
+mesheryctl system check
+
+# List available designs
+mesheryctl design list
+
+# Import a design from a local file
+mesheryctl design import -f designs/microservices-demo.yaml -s "Kubernetes Manifest"
+
+# List registered models in the registry
+mesheryctl registry list
+```
+
+For grounding an agent in your declared infrastructure, designs are especially valuable. A design encodes the intended state of your services and their relationships - precisely the context an agent needs when evaluating whether a proposed change is safe.
+
+### MeshSync - Continuous Cluster Discovery
+
+MeshSync is the Meshery Operator component that continuously observes cluster state and synchronizes it into Meshery's database. It runs inside the cluster and watches resources without requiring repeated `kubectl` calls from outside. From an agent's perspective, MeshSync data answers "what does Meshery currently believe about the cluster?" and includes topology, resource configurations, relationship mappings, and policy compliance status.
+
+### Designs as Context
+
+A Meshery design captures the intended configuration of one or more infrastructure components. Designs sit at the intersection of what you intended and what MeshSync reports as actual. Surfacing a relevant design to an agent before asking it to modify infrastructure gives it declared intent to compare against observed state. Store designs - including `designs/llm-mcp-gateway.yaml` and `designs/policy-guardrails.yaml` - in version control so retrieval pipelines can query them.
+
+## How to Surface State to an Agent
+
+There are two patterns for getting state into an agent's context window.
+
+### Pattern 1 - Tool Calls at Runtime
+
+The agent has access to tools that call `kubectl` or the Meshery API. When it needs to know the current replica count of a deployment, it calls the tool, receives the answer, and proceeds. This is the most accurate approach because the data is retrieved at the moment of need.
+
+The tradeoff is latency: each tool call adds a round trip. For highly volatile state (pod status, event logs), runtime tool calls are worth it. For stable state (registered models, environment configs), pre-fetching is cheaper.
+
+### Pattern 2 - Pre-fetched Context Injection
+
+Before the agent begins reasoning, a harness script fetches a snapshot of relevant state and injects it into the system prompt or first user message. This is appropriate for state that changes slowly and for reducing the number of tool calls needed during a task.
+
+```bash
+# Example harness script fragment
+NAMESPACE=production
+DEPLOYMENTS=$(kubectl get deployments -n $NAMESPACE -o json | jq '[.items[] | {name:.metadata.name, replicas:.spec.replicas, ready:.status.readyReplicas}]')
+echo "Current deployments in $NAMESPACE: $DEPLOYMENTS"
+```
+
+The fetched JSON is compact, structured, and directly usable by the agent.
+
+## A Note on MCP
+
+The Model Context Protocol (MCP) is a standard for connecting agents to tools and data sources in a structured, server-backed way. Rather than scripting tool calls ad hoc, MCP defines a contract that allows a Meshery server to expose resources - including MeshSync data, designs, and registry contents - to any compliant agent. MCP is covered fully in a later course in this learning path. For now, understand that the patterns described above (runtime tool calls, pre-fetched context) are what MCP formalizes and automates.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/retrieval-and-context-for-infrastructure/rag/quiz.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/retrieval-and-context-for-infrastructure/rag/quiz.md
@@ -1,0 +1,70 @@
+---
+title: "Module Quiz"
+passPercentage: 70
+type: "test"
+questions:
+  - id: "q1"
+    text: "Why is an LLM's training data insufficient for answering questions about your Kubernetes cluster without retrieval?"
+    type: "multiple-answers"
+    marks: 2
+    explanation: "LLM training data has a cutoff date and reflects generic public knowledge, not your specific cluster configuration, naming conventions, or internal runbooks. Both staleness and specificity are structural problems that retrieval addresses."
+    options:
+      - id: "a"
+        text: "Training data has a cutoff date and does not reflect current cluster state"
+        isCorrect: true
+      - id: "b"
+        text: "Training data is generic and does not include organization-specific configurations"
+        isCorrect: true
+      - id: "c"
+        text: "LLMs cannot process YAML or JSON output from kubectl"
+        isCorrect: false
+      - id: "d"
+        text: "Larger context windows eliminate the need for retrieval entirely"
+        isCorrect: false
+
+  - id: "q2"
+    text: "Which MeshSync component continuously observes cluster state and synchronizes it into Meshery's database?"
+    type: "single-answer"
+    marks: 2
+    explanation: "MeshSync is the Meshery Operator component that watches Kubernetes resources and keeps Meshery's view of the cluster current. It runs inside the cluster and updates continuously."
+    options:
+      - id: "a"
+        text: "mesheryctl"
+        isCorrect: false
+      - id: "b"
+        text: "Kanvas"
+        isCorrect: false
+      - id: "c"
+        text: "MeshSync"
+        isCorrect: true
+      - id: "d"
+        text: "The Meshery registry"
+        isCorrect: false
+
+  - id: "q3"
+    text: "What is the correct command to import the observability stack design into Meshery?"
+    type: "single-answer"
+    marks: 2
+    explanation: "mesheryctl design import requires the -f flag for the file path and the -s flag for the source type. 'Kubernetes Manifest' is the correct source type for YAML design files."
+    options:
+      - id: "a"
+        text: "mesheryctl design apply -f designs/observability-stack.yaml"
+        isCorrect: false
+      - id: "b"
+        text: "mesheryctl design import -f designs/observability-stack.yaml -s \"Kubernetes Manifest\""
+        isCorrect: true
+      - id: "c"
+        text: "kubectl apply -f designs/observability-stack.yaml"
+        isCorrect: false
+      - id: "d"
+        text: "mesheryctl system import designs/observability-stack.yaml"
+        isCorrect: false
+
+  - id: "q4"
+    text: "In the context of a RAG knowledge base for operations, what metadata field is most important for preventing an agent from acting on an outdated runbook?"
+    type: "short-answer"
+    marks: 2
+    correctAnswer: "last_indexed"
+    case_sensitive: false
+    explanation: "Attaching a last_indexed timestamp to each chunk allows the agent to surface the age of retrieved content. An agent that sees the timestamp can flag stale content rather than acting on it blindly."
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/retrieval-and-context-for-infrastructure/rag/why-agents-need-context/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/retrieval-and-context-for-infrastructure/rag/why-agents-need-context/_index.md
@@ -1,0 +1,54 @@
+---
+type: "page"
+id: "why-agents-need-context"
+title: "Why Agents Need Context"
+description: "Understand why finite context windows and stale training data make retrieval necessary for any agent that operates on live infrastructure."
+weight: 1
+---
+
+## The Two Problems with Training Data
+
+An LLM is a snapshot. Its weights encode patterns from text that existed up to a training cutoff - a date that is almost certainly months or years before the agent is running in your environment. That snapshot has two structural problems for infrastructure operations.
+
+**The data is stale.** Your cluster topology changes every time you deploy. Service versions drift. ConfigMaps are updated. Nodes are replaced. A model trained on documentation from twelve months ago does not know any of this. When it describes your cluster it is describing a composite hallucination assembled from similar clusters it has seen in training, not yours.
+
+**The data is generic.** Training corpora are full of Kubernetes tutorials, blog posts, and open-source configs. They contain almost nothing about your specific environment: your naming conventions, your custom resource definitions, your internal runbooks, your approved patterns. Even a perfectly current model cannot know what "production" means in your organization without being told.
+
+These are not bugs that a better model will fix. They are structural properties of how LLMs work. The answer is not a bigger model - it is better context.
+
+## The Context Window Is a Finite Resource
+
+Every invocation of an LLM operates within a context window: a fixed number of tokens that the model can attend to at once. This window holds the system prompt, the conversation history, any tool outputs, and whatever state you inject.
+
+Context windows have grown substantially over the past few years, but they remain finite, and large inputs have real costs in both latency and compute. More importantly, research consistently shows that models attend poorly to content buried deep in a long context - a phenomenon sometimes called the "lost in the middle" problem. You cannot solve the grounding problem by simply pasting your entire cluster state into the prompt.
+
+What you need is selective retrieval: fetch only the fragments of state that are relevant to the current query, and inject exactly those. That is the core idea behind retrieval-augmented generation (RAG).
+
+## RAG in One Sentence
+
+RAG = retrieve relevant context at query time, inject it into the prompt, then generate.
+
+The model's weights provide general language understanding and reasoning capability. The retrieved context provides the specific, current facts needed to answer correctly. Neither is sufficient alone.
+
+## Why This Matters More for Infrastructure Than for Chat
+
+In a customer support chatbot, a hallucinated answer is embarrassing. In an infrastructure agent, a hallucinated resource name or flag value can cause a service outage. The stakes are different.
+
+Consider an agent asked to scale a deployment. Without context, it guesses the deployment name, the namespace, and the current replica count. With retrieved context, it knows all three with certainty before it generates a single command. The difference between a confident hallucination and a grounded action is the retrieval step.
+
+| Without RAG | With RAG |
+|---|---|
+| Model guesses resource names | Model reads actual resource list from `kubectl` or MeshSync |
+| Outdated API versions | Current schema from registry |
+| Generic advice | Advice grounded in your specific state |
+| High hallucination risk | Risk bounded by retrieval quality |
+
+## The Three Questions for Every Agent
+
+Before you design a retrieval pipeline, answer these three questions about your agent:
+
+1. **What state does it need?** Cluster topology, service health, design files, runbooks, policy constraints - be specific.
+2. **How stale can that state be?** Real-time data requires live tool calls; reference data can be pre-indexed.
+3. **How much of it fits in context?** Be aggressive about filtering. Retrieve the minimum that allows a correct answer.
+
+The rest of this module answers each question in the context of Meshery and Kubernetes operations. In the next lesson you will see exactly which sources of truth are available to you and how to surface them to an agent.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/retrieval-and-context-for-infrastructure/test.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-engineering-foundations-for-platform-engineers/retrieval-and-context-for-infrastructure/test.md
@@ -1,0 +1,108 @@
+---
+title: "Course Test"
+passPercentage: 70
+type: "test"
+questions:
+  - id: "q1"
+    text: "Which of the following best describes the 'lost in the middle' problem with large context windows?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Research shows that LLMs attend poorly to content positioned in the middle of a long context. This means that simply injecting more state into the prompt does not guarantee the model will use all of it correctly."
+    options:
+      - id: "a"
+        text: "Models refuse to process context windows larger than a fixed token limit"
+        isCorrect: false
+      - id: "b"
+        text: "Models attend poorly to content buried deep in the middle of a long context"
+        isCorrect: true
+      - id: "c"
+        text: "Context windows lose tokens from the middle due to compression"
+        isCorrect: false
+      - id: "d"
+        text: "Retrieval systems fail to return the middle chunks from a document"
+        isCorrect: false
+
+  - id: "q2"
+    text: "An agent needs to know the current number of ready replicas for the payment service in the production namespace. Which approach provides the most accurate answer?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Runtime tool calls to kubectl query the live Kubernetes API at the moment of need, providing the most current data. Pre-fetched context may be seconds or minutes stale, and training data is far more stale."
+    options:
+      - id: "a"
+        text: "Inject a pre-fetched cluster snapshot taken at session start"
+        isCorrect: false
+      - id: "b"
+        text: "Rely on the LLM's training data for typical replica counts"
+        isCorrect: false
+      - id: "c"
+        text: "Execute a runtime tool call to kubectl get deployment"
+        isCorrect: true
+      - id: "d"
+        text: "Query the Meshery Catalog for the service definition"
+        isCorrect: false
+
+  - id: "q3"
+    text: "When building a retrieval knowledge base from runbooks, which chunking approach is most appropriate?"
+    type: "multiple-answers"
+    marks: 2
+    explanation: "Effective chunking for runbooks uses one procedure per chunk (to keep context coherent), attaches metadata like service tags and modification date (to enable filtered retrieval), and includes a brief header to prevent loss of context at boundaries."
+    options:
+      - id: "a"
+        text: "Split each runbook into one chunk per procedure, with a header naming the procedure and service"
+        isCorrect: true
+      - id: "b"
+        text: "Attach metadata including source file, last-modified date, and relevant service or namespace"
+        isCorrect: true
+      - id: "c"
+        text: "Store each entire runbook as a single chunk to preserve all context"
+        isCorrect: false
+      - id: "d"
+        text: "Split on every paragraph boundary with no metadata"
+        isCorrect: false
+
+  - id: "q4"
+    text: "What command verifies that Meshery is running correctly before an agent begins any retrieval or design import operations?"
+    type: "single-answer"
+    marks: 2
+    explanation: "mesheryctl system check verifies the health of a running Meshery deployment. It should be run before operations that depend on the Meshery control plane being available."
+    options:
+      - id: "a"
+        text: "mesheryctl system start"
+        isCorrect: false
+      - id: "b"
+        text: "kubectl get pods -n meshery"
+        isCorrect: false
+      - id: "c"
+        text: "mesheryctl system check"
+        isCorrect: true
+      - id: "d"
+        text: "mesheryctl registry list"
+        isCorrect: false
+
+  - id: "q5"
+    text: "Which of the following are valid safety requirements before an agent executes a write operation on a production cluster?"
+    type: "multiple-answers"
+    marks: 2
+    explanation: "Human approval, dry-run preview, and policy guardrail evaluation are all required before applying real changes. Bounding the blast radius to specific namespaces is also a best practice. Allowing agents to apply changes without approval violates the human-in-the-loop principle."
+    options:
+      - id: "a"
+        text: "Require explicit human approval before any kubectl apply or design import"
+        isCorrect: true
+      - id: "b"
+        text: "Run a dry-run and surface the output for review before executing"
+        isCorrect: true
+      - id: "c"
+        text: "Evaluate the proposed change against OPA or Meshery policy constraints"
+        isCorrect: true
+      - id: "d"
+        text: "Allow the agent to apply changes automatically if tool call accuracy exceeds 80%"
+        isCorrect: false
+
+  - id: "q6"
+    text: "What is the primary purpose of a 'golden task set' in the context of evaluating an infrastructure agent?"
+    type: "short-answer"
+    marks: 2
+    correctAnswer: "golden tasks"
+    case_sensitive: false
+    explanation: "A golden task set is a collection of representative, real-world scenarios paired with expected correct answers. It provides a reproducible benchmark for measuring whether the agent produces accurate, safe, and useful behavior across tasks that matter for your environment."
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/_index.md
@@ -1,0 +1,9 @@
+---
+type: "learning-path"
+title: "Foundations of Cloud Native Management with Meshery"
+description: "Start here. Build a working mental model of cloud native and Kubernetes, install Meshery and connect a cluster, and learn to capture infrastructure as reusable Meshery designs. The grounding for everything else in the academy."
+id: "2355e504-0606-4d1c-9f6f-9f7b07b5ad7d"
+banner: "banner.svg"
+weight: 1
+level: "beginner"
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/banner.svg
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/banner.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 220" role="img" aria-label="TCS Labs Academy">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b1f2a"/>
+      <stop offset="1" stop-color="#123642"/>
+    </linearGradient>
+    <linearGradient id="teal" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#00d3a7"/>
+      <stop offset="1" stop-color="#00b39f"/>
+    </linearGradient>
+  </defs>
+  <rect width="640" height="220" rx="14" fill="url(#bg)"/>
+  <rect x="0" y="0" width="8" height="220" fill="url(#teal)"/>
+  <!-- hexagon mark -->
+  <g transform="translate(96 110)">
+    <polygon points="0,-46 40,-23 40,23 0,46 -40,23 -40,-23" fill="none" stroke="url(#teal)" stroke-width="6"/>
+    <polygon points="0,-22 19,-11 19,11 0,22 -19,11 -19,-11" fill="url(#teal)" opacity="0.9"/>
+  </g>
+  <text x="170" y="96" font-family="Helvetica, Arial, sans-serif" font-size="40" font-weight="700" fill="#ffffff">TCS Labs Academy</text>
+  <text x="172" y="132" font-family="Helvetica, Arial, sans-serif" font-size="20" fill="#9fe8da">AI-Native Cloud Infrastructure with Meshery</text>
+  <text x="172" y="170" font-family="Helvetica, Arial, sans-serif" font-size="15" fill="#7fb6c4">LLMs &amp; coding agents for cloud native operations</text>
+</svg>

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/cloud-native-and-kubernetes-essentials/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/cloud-native-and-kubernetes-essentials/_index.md
@@ -1,0 +1,16 @@
+---
+type: "course"
+id: "cloud-native-and-kubernetes-essentials"
+title: "1. Cloud Native & Kubernetes Essentials"
+description: "Build the foundational vocabulary and mental models for cloud native infrastructure - containers, Kubernetes, declarative APIs, and GitOps - that every subsequent course in this learning path depends on."
+weight: 1
+tags: ["cloud-native", "kubernetes"]
+categories: "Cloud Native"
+level: "beginner"
+---
+
+Cloud native infrastructure is not a single product - it is a philosophy and an ecosystem built on containers, dynamic scheduling, declarative APIs, and continuous reconciliation. This course gives you the vocabulary and mental models you need before you start automating infrastructure with Meshery and coding agents.
+
+You will move from first principles - what a container actually is and why it matters - through Kubernetes core objects and the control loop, and land on the GitOps model of version-controlled desired state. Each concept builds directly on the previous one, and each maps to a lever you will pull later in the academy when you wire an LLM or agent to your cluster.
+
+By the end of this course you will be able to speak confidently about pods, deployments, reconciliation, and declarative infrastructure, and you will understand why that model is uniquely well-suited for AI-driven operations.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/cloud-native-and-kubernetes-essentials/foundations/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/cloud-native-and-kubernetes-essentials/foundations/_index.md
@@ -1,0 +1,10 @@
+---
+type: "module"
+id: "foundations"
+title: "Foundations"
+description: "Core concepts of cloud native computing - containers, Kubernetes, declarative infrastructure, and GitOps - that underpin everything else in this learning path."
+weight: 1
+tags: ["cloud-native"]
+categories: "Cloud Native"
+level: "beginner"
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/cloud-native-and-kubernetes-essentials/foundations/containers-and-images/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/cloud-native-and-kubernetes-essentials/foundations/containers-and-images/_index.md
@@ -1,0 +1,74 @@
+---
+type: "page"
+id: "containers-and-images"
+title: "Containers and Images"
+description: "Understand containers versus virtual machines, how images are built from layers, and why immutability makes containers the right unit of deployment for automated infrastructure."
+weight: 2
+---
+
+## Containers Are Not Virtual Machines
+
+The most common misconception about containers is that they are "lightweight VMs." They share a goal - process isolation - but the mechanism is fundamentally different.
+
+A virtual machine emulates hardware. Each VM carries a full operating system kernel, its own memory allocation, and its own network stack. Spinning one up takes seconds to minutes. Running 50 VMs on a single host is a resource-intensive proposition.
+
+A container uses Linux kernel primitives - **namespaces** and **cgroups** - to isolate a process (or a small set of processes) from the rest of the system:
+
+- **Namespaces** limit what the process can see: its own filesystem view, its own network interfaces, its own process table.
+- **cgroups** limit what the process can consume: CPU shares, memory ceilings, I/O bandwidth.
+
+The host kernel is shared. There is no hardware emulation. A container starts in milliseconds and consumes only the memory its process actually uses. A single node can run hundreds of containers.
+
+| Property | Container | Virtual Machine |
+|----------|-----------|-----------------|
+| Startup time | Milliseconds | Seconds to minutes |
+| Kernel | Shared with host | Dedicated, emulated |
+| Isolation unit | Process(es) | Full OS |
+| Typical density | Hundreds per node | Tens per host |
+| Portability | Image is self-contained | Depends on hypervisor |
+
+## Images and Layers
+
+A **container image** is the blueprint for a container. It is a read-only, layered filesystem snapshot that contains everything the application needs to run: the OS userspace libraries, the language runtime, the application binaries, and the configuration.
+
+Images are built in layers. Each instruction in a `Dockerfile` (or equivalent build file) adds a layer on top of the previous one:
+
+```text
+Base OS layer        (e.g. debian:bookworm-slim)
+  + Runtime layer    (e.g. apt-get install python3)
+  + App layer        (e.g. COPY app/ /app)
+  + Config layer     (e.g. ENV PORT=8080)
+```
+
+Layers are content-addressed and cached. If you rebuild an image and only the application code changed, the base and runtime layers are reused from cache. This makes builds fast and image storage efficient - multiple images that share a base layer store that layer only once in the registry.
+
+## Registries
+
+Images live in a **registry**: a content-addressable store that tags images with a name and version. When Kubernetes schedules a workload, each node pulls the image from the registry if it is not already cached locally.
+
+A fully-qualified image reference looks like this:
+
+```text
+registry.example.com/namespace/image-name:tag@sha256:digest
+```
+
+The `tag` (e.g. `v1.4.2`) is a human-readable alias. The `sha256` digest is the cryptographic content address of the image. In production environments, pinning to a digest rather than a mutable tag is the correct practice - it guarantees you are running exactly the artifact you tested, not whatever `latest` happens to point to today.
+
+## Immutability as an Operational Property
+
+An image, once built and pushed, is immutable. You cannot modify it in place. When a change is needed, you build a new image, push it to the registry under a new tag or digest, and update the workload definition to reference the new image.
+
+This immutability is not a constraint - it is a design property with significant operational consequences:
+
+- **Reproducibility** - the same image produces the same behavior on every node, in every environment, at any point in time.
+- **Auditability** - you can trace exactly what ran in production by examining image digests.
+- **Rollback** - reverting to a previous version means pointing to a previous image reference, not reconstructing a previous state by hand.
+- **Agent safety** - when a coding agent proposes an infrastructure change, it operates on image references and YAML manifests, not on running process state. The blast radius of a mistake is bounded and reversible.
+
+## The Container as the Unit of Deployment
+
+Kubernetes does not deploy applications - it deploys containers, grouped into **pods**. A pod is the smallest schedulable unit, and it contains one or more containers that share a network namespace and, optionally, storage volumes.
+
+The consequence for platform engineers: everything you want to run on Kubernetes must be packaged as a container image. That constraint is also an abstraction that lets Kubernetes (and Meshery, and coding agents operating through Meshery) reason about workloads uniformly, regardless of the language or framework they use.
+
+The image reference in a Deployment manifest is the contract between the platform team (which manages the cluster) and the application team (which builds the image). Meshery's registry models that contract and the relationships that flow from it.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/cloud-native-and-kubernetes-essentials/foundations/declarative-infrastructure-and-gitops/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/cloud-native-and-kubernetes-essentials/foundations/declarative-infrastructure-and-gitops/_index.md
@@ -1,0 +1,83 @@
+---
+type: "page"
+id: "declarative-infrastructure-and-gitops"
+title: "Declarative Infrastructure and GitOps"
+description: "Contrast declarative and imperative infrastructure models, understand desired state management, and learn why a version-controlled declarative model is the ideal substrate for LLM and agent-driven automation."
+weight: 4
+---
+
+## Declarative vs Imperative Infrastructure
+
+Every infrastructure management approach falls somewhere on a spectrum between two poles.
+
+**Imperative** means you describe the steps to reach a desired outcome: "SSH into each node, install the package, restart the service, update the config file." The operator - human or script - holds the model of current state in their head. The system itself has no memory of what was intended.
+
+**Declarative** means you describe the outcome and let the system figure out the steps: "I want three replicas of this pod running with this image in this namespace." The desired state is explicit, stored, and continuously reconciled against actual state.
+
+| Property | Imperative | Declarative |
+|----------|-----------|-------------|
+| State model | In the operator's head | In the manifest |
+| Drift detection | Manual | Automatic |
+| Rollback | Re-run previous commands | Apply previous manifest |
+| Auditability | Script history | Diff of manifest versions |
+| Agent-friendliness | Low - side effects are opaque | High - intent is explicit |
+
+Kubernetes is built entirely on the declarative model. Every resource you apply to the cluster is a desired-state specification. This is not a convention - it is enforced by the API.
+
+## Desired State and Reconciliation
+
+**Desired state** is the authoritative specification of what should be running. In Kubernetes, it lives in the cluster's etcd store as the `spec` field of every resource object. The `status` field reflects what is actually running. The control loop - described in the previous lesson - continuously works to make `status` match `spec`.
+
+This means:
+
+- If you delete a pod that is managed by a Deployment, the Deployment controller creates a new one.
+- If you scale a Deployment manually on the command line, a GitOps operator will revert it to the version in Git the next time it syncs.
+- If a node fails and its pods are rescheduled, the cluster moves back toward the desired replica count automatically.
+
+Desired state is also what gives infrastructure-as-code its power: the manifest files on disk are the source of truth. Any divergence between the files and the running cluster is a signal worth investigating.
+
+## The GitOps Model
+
+GitOps is the practice of managing desired state in a version control repository (Git) and using automated operators to continuously synchronize the cluster to match.
+
+The canonical GitOps workflow:
+
+1. **Declare** - write Kubernetes manifests and store them in a Git repository.
+2. **Review** - propose changes via pull requests, review and approve them through the normal code review process.
+3. **Merge** - merging the PR is the act of approving the infrastructure change.
+4. **Sync** - a GitOps operator (running inside the cluster) detects the change and applies it automatically.
+5. **Observe** - dashboards and alerts surface the resulting state.
+
+The critical insight is that the Git repository becomes the single source of truth for everything running in the cluster. You do not apply changes by running `kubectl apply` on a local machine. You commit a manifest change and let the operator apply it.
+
+```text
+Developer                Git Repository         GitOps Operator        Cluster
+   |                          |                      |                    |
+   |-- git commit/push -----> |                      |                    |
+   |                          |-- webhook/poll -----> |                    |
+   |                          |                      |-- kubectl apply --> |
+   |                          |                      |                    |-- reconcile
+   |                          |                      | <-- status -------- |
+```
+
+## Why This Model Is Ideal for LLM and Agent Automation
+
+Platform engineers who integrate coding agents into their workflow quickly discover that the declarative, GitOps model fits agentic automation naturally.
+
+**Agents work on files, not live systems.** An agent can read manifest files from a Git repository, propose edits, open a pull request, and wait for a human to review and merge. The human-in-the-loop step is the PR review - a familiar process with a clear approval gate. The agent never touches the cluster directly.
+
+**Desired state is machine-readable intent.** A YAML manifest is structured, versioned, and semantically meaningful. An LLM can read a Deployment spec and reason about what it does. It can compare two versions of a manifest and explain what changed and why it might matter. This is far more tractable than asking an agent to reason about the output of imperative scripts.
+
+**Drift is detectable and explainable.** When a GitOps operator reports that the cluster has drifted from the repository, an agent can read both the manifest and the live state, identify the delta, and propose a reconciliation. Meshery surfaces this kind of drift through MeshSync, which continuously synchronizes cluster state into Meshery's data plane.
+
+**You can import existing designs and version-control them.** If you have existing Kubernetes manifests, you can import them into Meshery with:
+
+```bash
+mesheryctl design import -f designs/microservices-demo.yaml -s "Kubernetes Manifest"
+```
+
+Meshery parses the manifests, models the relationships between objects, and renders a visual representation in Kanvas. You can then export the design, check it into Git, and manage it through the GitOps workflow - with an agent proposing changes and a human approving them.
+
+**Reversibility is built in.** Because every state is a commit, rolling back means reverting a commit. The blast radius of any change is bounded by the scope of the PR. An agent that makes a mistake does not corrupt live state irreversibly - it produces a manifest that a human can reject before it reaches the cluster.
+
+The declarative, version-controlled model is not just operationally sound - it is the architectural prerequisite for safe, auditable, human-supervised agentic infrastructure management. The rest of this learning path builds on top of this foundation.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/cloud-native-and-kubernetes-essentials/foundations/kubernetes-essentials/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/cloud-native-and-kubernetes-essentials/foundations/kubernetes-essentials/_index.md
@@ -1,0 +1,144 @@
+---
+type: "page"
+id: "kubernetes-essentials"
+title: "Kubernetes Essentials"
+description: "Understand Kubernetes core objects - Pods, Deployments, Services, and Namespaces - the reconciliation control loop, and why declarative APIs are the right interface for automated cluster management."
+weight: 3
+---
+
+## What Kubernetes Does
+
+Kubernetes is a container orchestrator. Its job is to accept a description of the workloads you want to run - expressed as YAML manifests - and make the cluster match that description. When the cluster drifts from the description (a node fails, a pod crashes, demand spikes), Kubernetes corrects the drift automatically.
+
+This is the **control loop** at its simplest: observe current state, compare to desired state, act to close the gap, repeat.
+
+## Core Objects
+
+Every Kubernetes workload is built from a small set of primitives. You need to recognize these on sight.
+
+### Pod
+
+A **Pod** is the smallest deployable unit. It wraps one or more containers that share a network namespace (they can reach each other on `localhost`) and, optionally, shared storage volumes.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-app
+  namespace: default
+spec:
+  containers:
+    - name: app
+      image: registry.example.com/demo-app:v1.2.0
+      ports:
+        - containerPort: 8080
+```
+
+You rarely create pods directly. Pods are ephemeral - if a node fails, the pod is gone. Higher-level objects manage pod lifecycle.
+
+### Deployment
+
+A **Deployment** declares that you want N replicas of a pod template running at all times. If a pod is deleted or crashes, the Deployment controller creates a replacement. If you update the pod template (e.g. a new image), the Deployment rolls out the change in a controlled fashion.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-app
+  namespace: default
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: demo-app
+  template:
+    metadata:
+      labels:
+        app: demo-app
+    spec:
+      containers:
+        - name: app
+          image: registry.example.com/demo-app:v1.2.0
+          ports:
+            - containerPort: 8080
+```
+
+### Service
+
+A **Service** provides a stable network endpoint for a set of pods selected by label. Pods come and go; the Service IP and DNS name stay constant.
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo-app
+  namespace: default
+spec:
+  selector:
+    app: demo-app
+  ports:
+    - port: 80
+      targetPort: 8080
+```
+
+### Namespace
+
+A **Namespace** is a logical partition inside a cluster. Resources in different namespaces are isolated by default. Platform teams use namespaces to separate workloads by team, environment, or trust boundary.
+
+```bash
+kubectl get namespaces
+kubectl get pods -n kube-system
+```
+
+## The Reconciliation Control Loop
+
+Every Kubernetes controller follows the same pattern:
+
+1. **Watch** - subscribe to events from the API server for resources of a given type
+2. **Observe** - read the current state of those resources
+3. **Diff** - compare current state to desired state in the spec
+4. **Act** - issue API calls to close the gap (create, update, or delete resources)
+5. **Repeat**
+
+This loop runs continuously. It is not a one-shot deployment script. If you manually delete a pod managed by a Deployment, the Deployment controller creates a new one within seconds. The cluster self-heals.
+
+This property is what makes declarative infrastructure safe to automate. A coding agent can apply a manifest and then observe the reconciliation loop to verify that the cluster converged to the desired state, without needing to manually track every intermediate step.
+
+## Essential kubectl Commands
+
+```bash
+# View cluster health
+kubectl get nodes
+
+# List pods in a namespace
+kubectl get pods -n <namespace>
+
+# Describe a resource (events, conditions, spec)
+kubectl describe deployment demo-app -n default
+
+# Apply a manifest (create or update)
+kubectl apply -f manifest.yaml
+
+# Watch rollout status
+kubectl rollout status deployment/demo-app -n default
+
+# View logs from a pod
+kubectl logs -f <pod-name> -n <namespace>
+```
+
+Meshery builds on top of these primitives. When you import a design with `mesheryctl design import -f designs/microservices-demo.yaml -s "Kubernetes Manifest"`, Meshery parses the Deployment, Service, and Namespace objects, models their relationships, and renders them in Kanvas - the visual designer. The same objects you manage with `kubectl` are the objects Meshery understands.
+
+## Why Declarative APIs Matter
+
+Kubernetes uses a declarative API: you tell the system what you want, not how to get there. You do not write a script that says "if there are fewer than 3 pods, start another one." You declare `replicas: 3` and Kubernetes figures out how to maintain that.
+
+This distinction is critical for automated operations. An LLM or coding agent can:
+
+- Read a manifest and reason about intent
+- Propose changes as diffs against existing manifests
+- Apply manifests and observe convergence
+- Detect drift by comparing live cluster state to the manifest on disk
+
+None of this is tractable with imperative scripts, whose current-state model exists only in the operator's head. The declarative API is the interface that makes agentic infrastructure management possible.
+
+For further reading on Kubernetes concepts, see the official documentation at [kubernetes.io/docs](https://kubernetes.io/docs/concepts/).

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/cloud-native-and-kubernetes-essentials/foundations/quiz.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/cloud-native-and-kubernetes-essentials/foundations/quiz.md
@@ -1,0 +1,70 @@
+---
+title: "Module Quiz"
+passPercentage: 70
+type: "test"
+questions:
+  - id: "q1"
+    text: "Which two Linux kernel primitives does a container use to isolate processes from the rest of the system?"
+    type: "multiple-answers"
+    marks: 2
+    explanation: "Containers rely on namespaces to limit what a process can see (filesystem, network, process table) and cgroups to limit what it can consume (CPU, memory, I/O). There is no hardware emulation involved - the host kernel is shared."
+    options:
+      - id: "a"
+        text: "Hypervisor and hardware emulation"
+        isCorrect: false
+      - id: "b"
+        text: "Namespaces"
+        isCorrect: true
+      - id: "c"
+        text: "cgroups"
+        isCorrect: true
+      - id: "d"
+        text: "Virtual network adapters"
+        isCorrect: false
+
+  - id: "q2"
+    text: "What is the smallest schedulable unit in Kubernetes?"
+    type: "single-answer"
+    marks: 2
+    explanation: "A Pod is the smallest deployable and schedulable unit in Kubernetes. It wraps one or more containers that share a network namespace. Deployments, StatefulSets, and DaemonSets all manage pods, but the pod itself is the atomic unit the scheduler places on a node."
+    options:
+      - id: "a"
+        text: "Container"
+        isCorrect: false
+      - id: "b"
+        text: "Deployment"
+        isCorrect: false
+      - id: "c"
+        text: "Pod"
+        isCorrect: true
+      - id: "d"
+        text: "Namespace"
+        isCorrect: false
+
+  - id: "q3"
+    text: "In the context of GitOps, what is the role of the Git repository?"
+    type: "single-answer"
+    marks: 2
+    explanation: "In a GitOps workflow, the Git repository is the single source of truth for desired cluster state. A GitOps operator continuously reconciles the cluster to match the manifests stored in the repository. Merging a pull request is the act of approving an infrastructure change."
+    options:
+      - id: "a"
+        text: "A backup location for kubectl command history"
+        isCorrect: false
+      - id: "b"
+        text: "The single source of truth for desired cluster state"
+        isCorrect: true
+      - id: "c"
+        text: "A read-only audit log of cluster events"
+        isCorrect: false
+      - id: "d"
+        text: "The registry where container images are stored"
+        isCorrect: false
+
+  - id: "q4"
+    text: "Which CNCF project is used as the container orchestrator in a cloud native stack?"
+    type: "short-answer"
+    marks: 2
+    explanation: "Kubernetes is the container orchestrator the industry has standardized on. It schedules containers onto nodes, manages their lifecycle, and continuously reconciles actual cluster state against the desired state declared in manifests."
+    correctAnswer: "Kubernetes"
+    case_sensitive: false
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/cloud-native-and-kubernetes-essentials/foundations/what-is-cloud-native/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/cloud-native-and-kubernetes-essentials/foundations/what-is-cloud-native/_index.md
@@ -1,0 +1,54 @@
+---
+type: "page"
+id: "what-is-cloud-native"
+title: "What Is Cloud Native?"
+description: "Define cloud native computing, understand its core pillars - containers, orchestration, and dynamic management - and explore why the CNCF ecosystem is the operating environment for AI-driven infrastructure."
+weight: 1
+---
+
+## Defining Cloud Native
+
+"Cloud native" is one of those terms the industry has stretched in many directions. A precise definition matters before you build on top of it.
+
+The Cloud Native Computing Foundation (CNCF) defines cloud native technologies as those that "empower organizations to build and run scalable applications in modern, dynamic environments such as public, private, and hybrid clouds." The operational emphasis is on **scalable**, **dynamic**, and **automated** - not on where the hardware lives.
+
+Three pillars hold that definition up:
+
+1. **Containers** - the unit of packaging and deployment. A container bundles an application and every dependency it needs into an immutable, portable artifact. It runs identically on a developer laptop and a production cluster.
+2. **Orchestration** - the system that decides where containers run, restarts them when they fail, scales them up under load, and routes traffic to healthy instances. Kubernetes is the orchestration layer the industry has standardized on.
+3. **Dynamic management** - the infrastructure responds to declared intent rather than manual intervention. When the desired state diverges from the actual state, a control loop corrects the divergence automatically.
+
+These three pillars are not independent. Containers make orchestration possible at scale. Orchestration makes dynamic management practical. Dynamic management is what allows coding agents and LLMs to safely operate on your infrastructure - they issue declarations, and the system reconciles.
+
+## The CNCF Landscape
+
+The CNCF hosts over 150 graduated, incubating, and sandbox projects spanning every layer of the cloud native stack: container runtimes, orchestrators, service meshes, observability tools, policy engines, CI/CD systems, and more. You can browse the full map at [landscape.cncf.io](https://landscape.cncf.io).
+
+The breadth of that landscape is both an asset and a challenge. The asset: every problem in distributed systems management has at least one open-source solution. The challenge: integrating those solutions, keeping them current, and reasoning about their collective state is operationally expensive.
+
+Meshery addresses that challenge directly. It models the CNCF landscape as a **registry** of components, models, and relationships. When you import a design into Meshery, it understands not just the raw Kubernetes YAML, but the semantic relationships between the objects - which service depends on which deployment, which ingress routes to which service, which policy applies to which workload. That semantic layer is what makes agentic operations tractable.
+
+## Why This Matters for AI-Driven Operations
+
+A coding agent managing infrastructure needs to:
+
+- Read the current state of the cluster
+- Understand what the desired state should be
+- Issue the correct API calls to move from current to desired
+- Verify that reconciliation succeeded
+
+Every step in that loop is easier when the infrastructure is cloud native. Container images are immutable artifacts with known contents. Kubernetes exposes a consistent, declarative API surface. The control loop provides a feedback signal the agent can observe. The CNCF ecosystem provides standardized interfaces - metrics, traces, logs, policy - that the agent can query.
+
+Contrast this with imperative, script-driven infrastructure, where the agent must reconstruct current state by running commands and parsing their output, issue imperative commands whose effects are not guaranteed, and have no systematic way to verify success. The cloud native model is not just operationally superior - it is the prerequisite for safe agentic automation.
+
+## What Comes Next
+
+The following lessons build each pillar in detail:
+
+- **Containers and Images** - what a container is at the kernel level, and why immutability matters
+- **Kubernetes Essentials** - the objects, the control loop, and the declarative API
+- **Declarative Infrastructure and GitOps** - how to manage desired state in version control, and why that is the right substrate for LLM-assisted operations
+
+Each lesson is self-contained but assumes the vocabulary introduced here. Take a moment to revisit the three pillars - containers, orchestration, dynamic management - before moving on.
+
+For a deeper orientation to the CNCF ecosystem, see the CNCF's own overview at [cncf.io](https://www.cncf.io) and the [landscape](https://landscape.cncf.io).

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/cloud-native-and-kubernetes-essentials/test.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/cloud-native-and-kubernetes-essentials/test.md
@@ -1,0 +1,122 @@
+---
+title: "Course Test"
+passPercentage: 70
+type: "test"
+questions:
+  - id: "q1"
+    text: "Which three pillars define cloud native computing according to the CNCF definition used in this course?"
+    type: "multiple-answers"
+    marks: 2
+    explanation: "The three pillars are containers (the unit of packaging and deployment), orchestration (the system that manages container lifecycle and scheduling), and dynamic management (the infrastructure responds to declared intent via continuous reconciliation). Virtual machines and SSH-based provisioning belong to the pre-cloud-native era."
+    options:
+      - id: "a"
+        text: "Containers"
+        isCorrect: true
+      - id: "b"
+        text: "Orchestration"
+        isCorrect: true
+      - id: "c"
+        text: "Dynamic management"
+        isCorrect: true
+      - id: "d"
+        text: "Virtual machines"
+        isCorrect: false
+      - id: "e"
+        text: "SSH-based provisioning"
+        isCorrect: false
+
+  - id: "q2"
+    text: "A container image is built in layers. What is the operational benefit of this layered architecture?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Layers are content-addressed and cached. When you rebuild an image and only the application code changed, the base OS and runtime layers are reused from cache. This makes builds faster and means multiple images sharing the same base layer store that layer only once in the registry."
+    options:
+      - id: "a"
+        text: "It allows the container to share a kernel with virtual machines on the same host"
+        isCorrect: false
+      - id: "b"
+        text: "Shared layers are cached and reused, making builds faster and storage more efficient"
+        isCorrect: true
+      - id: "c"
+        text: "It prevents the container from accessing the host filesystem"
+        isCorrect: false
+      - id: "d"
+        text: "It enables containers to run without a container runtime"
+        isCorrect: false
+
+  - id: "q3"
+    text: "What Kubernetes object provides a stable network endpoint for a set of pods selected by label?"
+    type: "single-answer"
+    marks: 2
+    explanation: "A Service provides a stable IP address and DNS name for a set of pods identified by a label selector. Pods are ephemeral and their IPs change; the Service IP and DNS name remain constant, making it the correct object for network routing within a cluster."
+    options:
+      - id: "a"
+        text: "Pod"
+        isCorrect: false
+      - id: "b"
+        text: "Deployment"
+        isCorrect: false
+      - id: "c"
+        text: "Namespace"
+        isCorrect: false
+      - id: "d"
+        text: "Service"
+        isCorrect: true
+
+  - id: "q4"
+    text: "In the Kubernetes reconciliation control loop, what happens immediately after a controller observes that current state differs from desired state?"
+    type: "single-answer"
+    marks: 2
+    explanation: "After observing a divergence between current state (status) and desired state (spec), the controller acts - it issues API calls to create, update, or delete resources to close the gap. The loop then repeats continuously: watch, observe, diff, act."
+    options:
+      - id: "a"
+        text: "The controller shuts down the affected pods and waits for a human operator"
+        isCorrect: false
+      - id: "b"
+        text: "The controller acts by issuing API calls to reconcile current state to desired state"
+        isCorrect: true
+      - id: "c"
+        text: "The controller logs a warning and waits for the next scheduled sync"
+        isCorrect: false
+      - id: "d"
+        text: "The controller updates the spec to match current state"
+        isCorrect: false
+
+  - id: "q5"
+    text: "Why is the declarative infrastructure model more suitable for coding agent automation than the imperative model?"
+    type: "multiple-answers"
+    marks: 2
+    explanation: "The declarative model stores desired state explicitly in manifests, which are machine-readable, diffable, and version-controlled. Agents can read manifests, propose changes as diffs, apply them, and observe reconciliation. Drift is automatically detectable. With imperative approaches, current state exists only in the operator's head and side effects are opaque to an agent."
+    options:
+      - id: "a"
+        text: "Desired state is explicit, stored in manifests, and machine-readable"
+        isCorrect: true
+      - id: "b"
+        text: "Drift between desired and actual state is automatically detectable"
+        isCorrect: true
+      - id: "c"
+        text: "Agents can execute shell scripts more efficiently than humans"
+        isCorrect: false
+      - id: "d"
+        text: "Rollback is as simple as applying a previous version of the manifest"
+        isCorrect: true
+
+  - id: "q6"
+    text: "Which mesheryctl command imports an existing Kubernetes manifest file into Meshery as a design?"
+    type: "single-answer"
+    marks: 2
+    explanation: "The correct command is `mesheryctl design import -f <file> -s \"Kubernetes Manifest\"`. This tells Meshery to parse the file as a Kubernetes Manifest source type, model the relationships between objects, and make the design available in Kanvas and the Meshery Catalog."
+    options:
+      - id: "a"
+        text: "mesheryctl system import -f designs/microservices-demo.yaml"
+        isCorrect: false
+      - id: "b"
+        text: "mesheryctl design apply -f designs/microservices-demo.yaml"
+        isCorrect: false
+      - id: "c"
+        text: "mesheryctl design import -f designs/microservices-demo.yaml -s \"Kubernetes Manifest\""
+        isCorrect: true
+      - id: "d"
+        text: "mesheryctl perf apply -f designs/microservices-demo.yaml"
+        isCorrect: false
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/exam.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/exam.md
@@ -1,0 +1,176 @@
+---
+title: "Learning Path Exam"
+passPercentage: 70
+timeLimit: 30
+type: "test"
+questions:
+  - id: "q1"
+    text: "Which statement best describes 'cloud native'?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Cloud native is an approach to building and running scalable applications using containers, orchestration, and dynamic management - not a single product."
+    options:
+      - id: "a"
+        text: "A specific product you buy from one vendor"
+        isCorrect: false
+      - id: "b"
+        text: "Building and running scalable apps with containers, orchestration, and dynamic management"
+        isCorrect: true
+      - id: "c"
+        text: "Running virtual machines in a public cloud"
+        isCorrect: false
+      - id: "d"
+        text: "A programming language for the cloud"
+        isCorrect: false
+  - id: "q2"
+    text: "What makes a container image well-suited to reliable, repeatable deployments?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Images are immutable and self-contained, so the same artifact runs the same way across environments."
+    options:
+      - id: "a"
+        text: "It is mutable and changes at runtime"
+        isCorrect: false
+      - id: "b"
+        text: "It is immutable and self-contained"
+        isCorrect: true
+      - id: "c"
+        text: "It always runs as root"
+        isCorrect: false
+      - id: "d"
+        text: "It requires a hypervisor"
+        isCorrect: false
+  - id: "q3"
+    text: "Which are core Kubernetes objects? (Select all that apply.)"
+    type: "multiple-answers"
+    marks: 3
+    explanation: "Pods, Deployments, Services, and Namespaces are core objects. A 'Dockerfile' is not a Kubernetes object."
+    options:
+      - id: "a"
+        text: "Pod"
+        isCorrect: true
+      - id: "b"
+        text: "Deployment"
+        isCorrect: true
+      - id: "c"
+        text: "Service"
+        isCorrect: true
+      - id: "d"
+        text: "Dockerfile"
+        isCorrect: false
+  - id: "q4"
+    text: "Why does a declarative, version-controlled model suit LLM/agent automation?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Declared desired state can be diffed, reviewed, and reverted - giving agents a reviewable artifact and a safe rollback path."
+    options:
+      - id: "a"
+        text: "It hides changes from reviewers"
+        isCorrect: false
+      - id: "b"
+        text: "Desired state can be diffed, reviewed, and reverted"
+        isCorrect: true
+      - id: "c"
+        text: "It removes the need for any human review"
+        isCorrect: false
+      - id: "d"
+        text: "It only works without Git"
+        isCorrect: false
+  - id: "q5"
+    text: "In one phrase, what is Meshery?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Meshery is the open-source cloud native manager for designing and operating infrastructure across clusters."
+    options:
+      - id: "a"
+        text: "A hosted LLM API"
+        isCorrect: false
+      - id: "b"
+        text: "The open-source cloud native manager"
+        isCorrect: true
+      - id: "c"
+        text: "A container registry"
+        isCorrect: false
+      - id: "d"
+        text: "A Linux distribution"
+        isCorrect: false
+  - id: "q6"
+    text: "Which Meshery component provides real-time discovery and state sync of cluster resources?"
+    type: "short-answer"
+    marks: 2
+    correctAnswer: "MeshSync"
+    case_sensitive: false
+    explanation: "MeshSync discovers and continuously syncs the state of resources in connected clusters."
+  - id: "q7"
+    text: "Which command imports a Kubernetes manifest as a Meshery design?"
+    type: "single-answer"
+    marks: 2
+    explanation: "mesheryctl design import -f <file> -s \"Kubernetes Manifest\" imports a manifest as a design."
+    options:
+      - id: "a"
+        text: "mesheryctl design import -f <file> -s \"Kubernetes Manifest\""
+        isCorrect: true
+      - id: "b"
+        text: "kubectl meshery apply <file>"
+        isCorrect: false
+      - id: "c"
+        text: "mesheryctl apply design <file>"
+        isCorrect: false
+      - id: "d"
+        text: "helm install meshery <file>"
+        isCorrect: false
+  - id: "q8"
+    text: "What does the Meshery registry's relationships layer enable?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Relationships capture how components relate, enabling validation that catches semantic misconfigurations a plain schema check would miss."
+    options:
+      - id: "a"
+        text: "Faster container image builds"
+        isCorrect: false
+      - id: "b"
+        text: "Validation of how components relate, catching misconfigurations"
+        isCorrect: true
+      - id: "c"
+        text: "Automatic GPU scheduling"
+        isCorrect: false
+      - id: "d"
+        text: "Encryption of secrets at rest"
+        isCorrect: false
+  - id: "q9"
+    text: "Why store Meshery designs in Git (designs as code)?"
+    type: "multiple-answers"
+    marks: 3
+    explanation: "Versioning, review via pull requests, and easy rollback are all benefits. Git does not make designs deploy without a target cluster."
+    options:
+      - id: "a"
+        text: "Version history and auditability"
+        isCorrect: true
+      - id: "b"
+        text: "Review changes via pull requests"
+        isCorrect: true
+      - id: "c"
+        text: "Roll back to a previous version"
+        isCorrect: true
+      - id: "d"
+        text: "It deploys designs without any cluster"
+        isCorrect: false
+  - id: "q10"
+    text: "What is the Meshery Catalog used for?"
+    type: "single-answer"
+    marks: 2
+    explanation: "The Catalog stores and shares reusable designs as templates."
+    options:
+      - id: "a"
+        text: "Storing and sharing reusable designs as templates"
+        isCorrect: true
+      - id: "b"
+        text: "Hosting container images"
+        isCorrect: false
+      - id: "c"
+        text: "Running CI pipelines"
+        isCorrect: false
+      - id: "d"
+        text: "Managing DNS records"
+        isCorrect: false
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/infrastructure-as-designs/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/infrastructure-as-designs/_index.md
@@ -1,0 +1,16 @@
+---
+type: "course"
+id: "infrastructure-as-designs"
+title: "3. Infrastructure as Designs"
+description: "Learn how Meshery designs capture infrastructure intent as version-controlled, shareable artifacts - and how to import, inspect, deploy, and collaborate on them using Kanvas, the Catalog, GitHub, and Meshery's environment model."
+weight: 3
+tags: ["meshery", "designs"]
+categories: "Meshery"
+level: "beginner"
+---
+
+A Meshery design is the unit of infrastructure intent. It is a YAML document that describes components - Kubernetes resources, service mesh configuration, policies - along with the relationships between them. Designs are declarative, portable, and version-controllable, which makes them the natural pairing for agent-generated infrastructure changes.
+
+This course walks you through the full design lifecycle: authoring and importing a design, opening it in Kanvas for visual inspection, deploying it to a cluster, saving it to the Catalog so your team can reuse it, and backing it with a GitHub repository so that pull requests carry infrastructure previews alongside code changes.
+
+The final module introduces environments and workspaces - the organizational model Meshery uses to scope designs across teams and promotion stages - giving you the mental model you need to safely promote a design from development through to production.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/infrastructure-as-designs/designs/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/infrastructure-as-designs/designs/_index.md
@@ -1,0 +1,10 @@
+---
+type: "module"
+id: "designs"
+title: "Designs"
+description: "Work with Meshery designs from first import through catalog sharing, GitHub-backed versioning, and environment-based promotion."
+weight: 1
+tags: ["designs"]
+categories: "Meshery"
+level: "beginner"
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/infrastructure-as-designs/designs/authoring-your-first-design/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/infrastructure-as-designs/designs/authoring-your-first-design/_index.md
@@ -1,0 +1,76 @@
+---
+type: "page"
+id: "authoring-your-first-design"
+title: "Authoring Your First Design"
+description: "Understand what a Meshery design is, import a real design from file, inspect it in Kanvas, and deploy it to a cluster."
+weight: 1
+---
+
+## What is a Meshery Design?
+
+A Meshery design is a YAML document that expresses infrastructure intent. It combines Kubernetes resource manifests with Meshery-specific metadata: component annotations, relationship declarations, visual layout hints for Kanvas, and optional policy references. Think of it as a blueprint that can be opened, validated, versioned, and deployed - the single artifact that moves from a developer's laptop to a production cluster.
+
+Designs are distinct from raw Kubernetes manifests in one important way: they carry _relationships_. A design can declare that a Deployment depends on a ConfigMap, that a Service should route to specific Pod labels, or that two microservices communicate over a particular network path. Meshery's registry uses those relationships to validate the design before deployment and to render a meaningful topology in Kanvas.
+
+The canonical format for a design file uses the `.yaml` extension and is importable from any source Meshery understands - local files, URLs, GitHub repositories, or the Catalog.
+
+## Importing the Academy Design
+
+The academy ships a sample design at `designs/microservices-demo.yaml`. This file contains a realistic microservices topology - several Deployments, Services, and a Gateway resource - sized to run on a small local cluster.
+
+Import it with `mesheryctl`:
+
+```bash
+mesheryctl design import -f designs/microservices-demo.yaml -s "Kubernetes Manifest"
+```
+
+The `-f` flag accepts a relative or absolute file path. The `-s` flag tells Meshery which source schema to apply when parsing the file. `"Kubernetes Manifest"` is the correct schema for standard Kubernetes YAML; Meshery will parse each document in the file, resolve its kind, and map it to a registered component in the registry.
+
+A successful import returns the design ID and a confirmation line:
+
+```text
+Design imported successfully.
+Design ID: <uuid>
+```
+
+If the import fails, verify that Meshery is running (`mesheryctl system check`) and that the file path is correct relative to your working directory.
+
+## Opening the Design in Kanvas
+
+After import, open the Meshery UI and navigate to **Designs** in the left sidebar. You will see `microservices-demo` listed. Click it to open the design in Kanvas, Meshery's visual infrastructure designer.
+
+Kanvas renders each component as a node and draws edges between components that share a declared relationship. For the microservices demo you will see:
+
+| Node type | What it represents |
+|---|---|
+| Deployment | A workload that Kubernetes manages as a replica set |
+| Service | A stable network endpoint that routes to Pod labels |
+| ConfigMap | Configuration data mounted into Pods |
+| Gateway | An ingress resource routing external traffic |
+
+Use the canvas controls to zoom, pan, and select individual nodes. Clicking a node opens its component panel on the right - a structured form backed by the JSON Schema for that component kind. You can edit fields directly in the panel and Kanvas will update the underlying YAML in real time.
+
+Take a few minutes to explore the topology. Notice how Kanvas draws an arrow from each Service to its target Deployment - this relationship was inferred from the `selector` fields in the manifest, not hand-drawn. That inference is the registry's work.
+
+## Deploying the Design
+
+When you are satisfied with the design, deploy it to the connected cluster from the Kanvas toolbar. Click the **Deploy** button (the upward-pointing arrow icon) and confirm the target environment in the dialog that appears.
+
+Meshery sends each component to the Kubernetes API server in dependency order: ConfigMaps and Secrets first, then Deployments, then Services. Progress is shown in the **Notifications** panel. When all components reach a ready state, the nodes in Kanvas update with a green status indicator.
+
+You can also deploy from the CLI:
+
+```bash
+mesheryctl design deploy --id <design-id>
+```
+
+Replace `<design-id>` with the UUID returned during import, or retrieve it with `mesheryctl design list`.
+
+To confirm the workloads are running on the cluster:
+
+```bash
+kubectl get pods -n default
+kubectl get svc -n default
+```
+
+You have now completed the full import-inspect-deploy cycle for a Meshery design. The next lesson covers the Catalog - the mechanism for saving designs so your team can discover and reuse them.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/infrastructure-as-designs/designs/designs-as-code-with-github/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/infrastructure-as-designs/designs/designs-as-code-with-github/_index.md
@@ -1,0 +1,97 @@
+---
+type: "page"
+id: "designs-as-code-with-github"
+title: "Designs as Code with GitHub"
+description: "Back Meshery designs with a GitHub repository, version them alongside application code, and understand why design-as-code is essential for agent-generated infrastructure changes."
+weight: 3
+---
+
+## Why Designs Belong in Git
+
+A Meshery design deployed directly from the UI or CLI exists only in Meshery's local database. If the instance is reset, or a teammate needs to reproduce the deployment, there is no durable record. Checking designs into a GitHub repository adds commit history, branch isolation, code review, and CI/CD integration.
+
+Design-as-code matters specifically for agent-generated infrastructure. When a coding agent modifies a design - adding a sidecar, adjusting resource limits, wiring a new service - that change must go through the same review process as application code. A pull request is the natural human-in-the-loop checkpoint: the agent proposes, a human reviews, and the merge triggers deployment. Without version control, agent changes are invisible and irreversible.
+
+## Setting Up a GitHub-Backed Design Repository
+
+The minimal structure for a design repository is straightforward:
+
+```text
+infrastructure/
+  designs/
+    microservices-demo.yaml
+    observability-stack.yaml
+    llm-mcp-gateway.yaml
+    policy-guardrails.yaml
+  README.md
+```
+
+Each `.yaml` file is a Meshery design exported from Kanvas or produced by an agent. The repository is the source of truth; Meshery is the deployment engine.
+
+To export a design from Meshery for committing to the repository, use the CLI:
+
+```bash
+mesheryctl design export --id <design-id> -o designs/microservices-demo.yaml
+```
+
+Commit and push the file as you would any other code change:
+
+```bash
+git add designs/microservices-demo.yaml
+git commit -s -m "feat: add microservices demo design"
+git push origin main
+```
+
+## Importing from GitHub
+
+Once designs are in a repository, import them directly from a raw URL rather than a local file path:
+
+```bash
+mesheryctl design import \
+  -f https://raw.githubusercontent.com/<org>/<repo>/main/designs/microservices-demo.yaml \
+  -s "Kubernetes Manifest"
+```
+
+This works in CI pipelines as well. A GitHub Actions workflow can import a design and deploy it on every merge to `main`, giving you continuous delivery for infrastructure alongside application deployments.
+
+## Pull-Request Previews
+
+The most powerful pattern in design-as-code is the pull-request preview: when a pull request modifies a design file, a CI job imports the changed design into a preview environment and posts a Kanvas snapshot as a PR comment. Reviewers see the topology diff - what was added, removed, or changed - without needing to clone the branch and load it locally.
+
+The workflow looks like this:
+
+1. A developer (or a coding agent) opens a PR that modifies `designs/microservices-demo.yaml`.
+2. A CI job runs `mesheryctl design import` against the changed file in a staging Meshery instance.
+3. The job captures a Kanvas snapshot and posts it as a PR comment alongside a diff of the YAML.
+4. A platform engineer reviews the visual topology and the YAML diff, then approves or requests changes.
+5. On merge, a second job deploys the design to the production environment.
+
+This pattern is why design-as-code pairs so naturally with agent-generated changes. An agent operating in an agentic loop can draft infrastructure changes, open a pull request, and surface the preview for human review - without requiring the reviewing engineer to understand the raw YAML. The visual diff in Kanvas is the communication layer between the agent and the human.
+
+## Versioning and Rollback
+
+Because designs are files in Git, every change is addressable by commit SHA. Rolling back to a previous infrastructure state is a `git revert` followed by a re-import and re-deploy:
+
+```bash
+git revert <commit-sha>
+git push origin main
+# CI imports and deploys the reverted design automatically
+```
+
+## Why Agent-Generated Changes Need This Model
+
+An agent generates infrastructure changes at a rate that makes manual auditing impractical without tooling. The Git-backed design workflow provides three essential guardrails:
+
+| Guardrail | Mechanism |
+|---|---|
+| Auditability | Every agent change is a commit with a message, author, and timestamp |
+| Reviewability | Pull requests expose the change for human approval before deployment |
+| Reversibility | Git history makes rollback deterministic and fast |
+
+The academy's `designs/llm-mcp-gateway.yaml` design represents the kind of infrastructure an agent might generate or modify: a gateway that routes traffic between an LLM inference service and downstream consumers. Import it and inspect it in Kanvas to see how a more complex agent-related topology is structured:
+
+```bash
+mesheryctl design import -f designs/llm-mcp-gateway.yaml -s "Kubernetes Manifest"
+```
+
+In the next lesson you will learn how Meshery's environments and workspaces provide the organizational model for promoting designs across dev, staging, and production stages.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/infrastructure-as-designs/designs/environments-and-workspaces/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/infrastructure-as-designs/designs/environments-and-workspaces/_index.md
@@ -1,0 +1,83 @@
+---
+type: "page"
+id: "environments-and-workspaces"
+title: "Environments and Workspaces"
+description: "Understand Meshery environments, workspaces, teams, and RBAC, and learn how to promote designs across development, staging, and production stages."
+weight: 4
+---
+
+## The Organizational Model
+
+Meshery provides two layered abstractions for organizing infrastructure: **environments** and **workspaces**. Together they let a platform team manage multiple clusters and promotion stages without mixing concerns. When coding agents are generating changes, these boundaries are critical - an agent acting in a development context must not be able to affect a production cluster.
+
+## Environments
+
+An environment in Meshery is a named grouping of connections - cluster connections, metrics endpoints, and other infrastructure integrations. An environment represents a deployment target. Common environments in a typical organization:
+
+| Environment | Cluster | Purpose |
+|---|---|---|
+| `dev` | `minikube` or `kind` | Individual developer iteration |
+| `staging` | Shared cluster, isolated namespace | Integration testing and pre-release validation |
+| `production` | Production cluster | Live traffic |
+
+You create and manage environments in the Meshery UI under **Settings > Environments**, or via the API. Each environment holds one or more connections, which are authenticated references to cluster API servers. When you deploy a design, you select the target environment; Meshery routes the deployment to the connections in that environment.
+
+This separation means that importing a design into Meshery does not automatically deploy it anywhere. The import step stores the design; the deploy step targets a specific environment. That two-step model is an important safety boundary, especially when agents are generating designs automatically.
+
+## Workspaces
+
+A workspace is a collaborative container that groups environments, designs, and team members. It is the unit of access control in Meshery. A workspace might map to a business unit, an application squad, or a product area.
+
+Key properties of a workspace:
+
+- **Members** - users who can view and modify resources in the workspace
+- **Environments** - the deployment targets available to workspace members
+- **Designs** - the designs owned by the workspace
+- **Tokens** - API tokens scoped to the workspace, used by CI pipelines and coding agents
+
+When a coding agent operates against Meshery, it authenticates with a workspace-scoped token. That token grants the agent access only to the designs, environments, and connections associated with that workspace - nothing outside it. This is the RBAC boundary that prevents an agent from reaching across workspace boundaries.
+
+## Teams and RBAC
+
+Meshery Cloud provides role-based access control at the workspace level. Three built-in roles cover most use cases:
+
+| Role | Permissions |
+|---|---|
+| Viewer | Read designs, view deployments, read environment status |
+| Editor | All Viewer permissions, plus create and modify designs |
+| Admin | All Editor permissions, plus manage members, environments, and tokens |
+
+In practice, individual contributors are Editors in their team's workspace, senior platform engineers are Admins, and service accounts used by CI pipelines or coding agents are granted the narrowest role sufficient for their task - usually Editor in a single non-production workspace.
+
+## Promoting Designs Across Environments
+
+Design promotion moves a validated design from one environment to the next. The workflow integrates with the GitHub-backed design pattern from the previous lesson:
+
+1. A developer or coding agent creates or modifies a design in the `dev` workspace and deploys it to `dev` for initial validation.
+2. A pull request opens against the main branch. The CI pipeline imports the design into `staging` and runs validation checks.
+3. After approval and merge, the pipeline deploys to `staging`. Automated tests run against the live deployment.
+4. A final approval gate triggers deployment to `production`.
+
+The CLI commands for each promotion step follow the same pattern:
+
+```bash
+# Deploy to staging
+mesheryctl design deploy --id <design-id> --environment staging
+
+# Deploy to production after approval
+mesheryctl design deploy --id <design-id> --environment production
+```
+
+The `--environment` flag accepts the environment name configured in Meshery. The deployment is routed to all cluster connections in that environment.
+
+## Policy Guardrails at Promotion Boundaries
+
+The academy's `designs/policy-guardrails.yaml` design demonstrates how OPA-based policy checks can be embedded in the design lifecycle. Import it to see how policy components sit alongside workload components in a design topology:
+
+```bash
+mesheryctl design import -f designs/policy-guardrails.yaml -s "Kubernetes Manifest"
+```
+
+Meshery evaluates OPA policies against a design before deployment, rejecting those that violate organizational standards: no `latest` image tags in production, required resource limits, mandatory network policies. Combined with environment-scoped deployment and workspace RBAC, policy checks make agent-generated infrastructure safe to promote automatically.
+
+With environments, workspaces, and policy guardrails in place, you have a complete organizational model for managing designs at scale.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/infrastructure-as-designs/designs/quiz.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/infrastructure-as-designs/designs/quiz.md
@@ -1,0 +1,70 @@
+---
+title: "Module Quiz"
+passPercentage: 70
+type: "test"
+questions:
+  - id: "q1"
+    text: "Which command imports a local Kubernetes manifest file into Meshery as a design?"
+    type: "single-answer"
+    marks: 2
+    explanation: "The correct command is `mesheryctl design import -f <file> -s \"Kubernetes Manifest\"`. The `-f` flag specifies the file path and `-s` specifies the source schema to use when parsing the file."
+    options:
+      - id: "a"
+        text: "mesheryctl design load -f designs/microservices-demo.yaml"
+        isCorrect: false
+      - id: "b"
+        text: "mesheryctl design import -f designs/microservices-demo.yaml -s \"Kubernetes Manifest\""
+        isCorrect: true
+      - id: "c"
+        text: "mesheryctl design apply -f designs/microservices-demo.yaml"
+        isCorrect: false
+      - id: "d"
+        text: "mesheryctl design push designs/microservices-demo.yaml"
+        isCorrect: false
+
+  - id: "q2"
+    text: "What does the Meshery Catalog provide that a raw YAML file in a Git repository does not?"
+    type: "multiple-answers"
+    marks: 2
+    explanation: "The Catalog wraps designs in named, versioned, documented artifacts with tags, compatibility metadata, and a visual Kanvas preview. Raw YAML files have none of those discovery and documentation features built in."
+    options:
+      - id: "a"
+        text: "A visual topology preview rendered by Kanvas"
+        isCorrect: true
+      - id: "b"
+        text: "Searchable metadata including tags and compatibility information"
+        isCorrect: true
+      - id: "c"
+        text: "The ability to version infrastructure changes over time"
+        isCorrect: false
+      - id: "d"
+        text: "A named, documented artifact that can be cloned as a template"
+        isCorrect: true
+
+  - id: "q3"
+    text: "In the Meshery organizational model, what is a workspace?"
+    type: "single-answer"
+    marks: 2
+    explanation: "A workspace is a collaborative container that groups environments, designs, and team members and is the unit of access control in Meshery. Environments are deployment targets; clusters are infrastructure; namespaces are a Kubernetes concept."
+    options:
+      - id: "a"
+        text: "A named group of Kubernetes namespaces"
+        isCorrect: false
+      - id: "b"
+        text: "A collaborative container that groups environments, designs, and team members and is the unit of access control"
+        isCorrect: true
+      - id: "c"
+        text: "A deployment target backed by one or more cluster connections"
+        isCorrect: false
+      - id: "d"
+        text: "A cluster-level resource created by the Meshery Operator"
+        isCorrect: false
+
+  - id: "q4"
+    text: "Why does backing Meshery designs with a GitHub repository matter specifically for agent-generated infrastructure changes?"
+    type: "short-answer"
+    marks: 2
+    correctAnswer: "version control"
+    case_sensitive: false
+    explanation: "Version control provides the three essential guardrails for agent-generated changes: auditability (every change is a commit), reviewability (pull requests expose changes for human approval), and reversibility (git history makes rollback deterministic). Without version control, agent changes are invisible and irreversible."
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/infrastructure-as-designs/designs/the-meshery-catalog/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/infrastructure-as-designs/designs/the-meshery-catalog/_index.md
@@ -1,0 +1,82 @@
+---
+type: "page"
+id: "the-meshery-catalog"
+title: "The Meshery Catalog"
+description: "Save designs to the Meshery Catalog, use curated templates, and share reusable infrastructure patterns with your team."
+weight: 2
+---
+
+## What is the Meshery Catalog?
+
+The [Meshery Catalog](https://meshery.io/catalog) is a curated library of designs, filters, and patterns that the Meshery community and your organization can publish, discover, and deploy. It operates like a package registry for infrastructure intent: you publish a design once, and any team member - or any coding agent with access to Meshery - can import and deploy it on demand.
+
+The Catalog solves a specific problem: raw YAML checked into a repository is opaque to anyone who did not write it. A Catalog entry wraps that YAML in a named, versioned, documented artifact with a description, tags, compatibility information, and a visual preview rendered by Kanvas. The artifact is searchable, filterable, and deployable without requiring the recipient to understand the underlying manifests.
+
+## Saving a Design to the Catalog
+
+After you have imported and validated a design (as you did in the previous lesson), you can publish it to the Catalog directly from Kanvas.
+
+1. Open the design in Kanvas.
+2. Click the **Publish** button in the top toolbar.
+3. In the publish dialog, fill in the required metadata:
+   - **Name** - a short, descriptive label (e.g. `microservices-demo`)
+   - **Description** - one or two sentences about what the design deploys and why
+   - **Tags** - keywords that make the design discoverable (`kubernetes`, `microservices`, `demo`)
+   - **Compatibility** - the Kubernetes version range the design targets
+4. Click **Publish to Catalog**.
+
+Meshery sends the design YAML and metadata to the Catalog backend. After a brief review period for community submissions, the design appears in the Catalog UI and is discoverable via `mesheryctl`:
+
+```bash
+mesheryctl catalog list
+mesheryctl catalog search --name microservices-demo
+```
+
+For private organizational Catalogs (available in Meshery Cloud), published designs are immediately visible to members of your organization without a review step.
+
+## Using Catalog Entries as Templates
+
+A Catalog entry is not just an artifact you deploy as-is - it is a template you can clone, modify, and re-publish. This is the recommended starting point for new designs: find the closest matching Catalog entry, clone it, adapt the components to your environment, and publish the variant under a new name.
+
+To clone a Catalog entry from the CLI:
+
+```bash
+mesheryctl catalog clone --id <catalog-entry-id> --name my-custom-design
+```
+
+This pulls the design into your local Meshery instance as a new draft with the name you specified. Open it in Kanvas, make your changes, and follow the publish flow above when ready.
+
+Templates are especially valuable when a coding agent is generating infrastructure. An agent can use a Catalog entry as a base context - passing the YAML to its context window - and then apply targeted mutations to produce a variant that matches a specific requirement. The agent does not need to produce valid Kubernetes YAML from scratch; it only needs to make correct, scoped changes to a known-good template.
+
+## Discovering Community Designs
+
+The public Meshery Catalog at [meshery.io/catalog](https://meshery.io/catalog) contains designs contributed by the community. Categories include:
+
+| Category | Example entries |
+|---|---|
+| Observability | Prometheus + Grafana stacks, distributed tracing topologies |
+| Networking | Istio service mesh configurations, Ingress patterns |
+| Security | OPA policy bundles, NetworkPolicy templates |
+| Platform | Multi-tenant namespace scaffolding, RBAC role sets |
+
+Browse the Catalog in the UI or filter by tag:
+
+```bash
+mesheryctl catalog list --tag observability
+```
+
+To import a community design directly into your Meshery instance by its Catalog ID:
+
+```bash
+mesheryctl design import -f https://catalog.meshery.io/<catalog-entry-id>.yaml -s "Kubernetes Manifest"
+```
+
+The academy's `designs/observability-stack.yaml` file is modeled on the kind of entry you would find in the Observability category - a complete Prometheus and Grafana deployment ready to scrape a running cluster. Import it with the same command you used for the microservices demo:
+
+```bash
+mesheryctl design import -f designs/observability-stack.yaml -s "Kubernetes Manifest"
+```
+
+Open it in Kanvas to see how a multi-component observability stack is represented as a design topology, then consider how you would publish a variant of it to your organization's private Catalog.
+
+The next lesson extends the Catalog concept into version control: backing your designs with GitHub so that every change is auditable and pull requests carry an infrastructure preview.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/infrastructure-as-designs/test.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/infrastructure-as-designs/test.md
@@ -1,0 +1,119 @@
+---
+title: "Course Test"
+passPercentage: 70
+type: "test"
+questions:
+  - id: "q1"
+    text: "A Meshery design differs from a plain Kubernetes manifest primarily because it:"
+    type: "single-answer"
+    marks: 2
+    explanation: "A Meshery design carries relationship declarations between components - dependencies, communication paths, routing rules - that Kubernetes manifests do not express natively. These relationships enable validation and visual topology rendering in Kanvas."
+    options:
+      - id: "a"
+        text: "Uses a proprietary binary format that is smaller than YAML"
+        isCorrect: false
+      - id: "b"
+        text: "Can only be deployed via the Meshery UI, not the CLI"
+        isCorrect: false
+      - id: "c"
+        text: "Carries relationship declarations between components that enable validation and topology rendering"
+        isCorrect: true
+      - id: "d"
+        text: "Requires a Meshery Operator to be installed before it can be stored"
+        isCorrect: false
+
+  - id: "q2"
+    text: "After running `mesheryctl design import -f designs/microservices-demo.yaml -s \"Kubernetes Manifest\"`, what does Meshery return on success?"
+    type: "single-answer"
+    marks: 2
+    explanation: "A successful import returns a confirmation message and the UUID assigned to the imported design. This ID is used in subsequent commands such as `mesheryctl design deploy --id <design-id>`."
+    options:
+      - id: "a"
+        text: "A Kanvas URL where the design can be viewed immediately"
+        isCorrect: false
+      - id: "b"
+        text: "A confirmation message and the design ID (UUID)"
+        isCorrect: true
+      - id: "c"
+        text: "A diff showing what changed relative to the current cluster state"
+        isCorrect: false
+      - id: "d"
+        text: "An OPA policy report listing any policy violations in the manifest"
+        isCorrect: false
+
+  - id: "q3"
+    text: "Which of the following actions are part of the recommended pull-request preview workflow for GitHub-backed designs?"
+    type: "multiple-answers"
+    marks: 2
+    explanation: "The PR preview workflow involves: a CI job importing the changed design into a staging Meshery instance, capturing a Kanvas snapshot and posting it as a PR comment, and a platform engineer reviewing both the visual topology and the YAML diff before approving. Automatic deployment to production on PR open (before merge and approval) is not recommended."
+    options:
+      - id: "a"
+        text: "A CI job imports the modified design into a staging Meshery instance when a PR is opened"
+        isCorrect: true
+      - id: "b"
+        text: "A Kanvas snapshot of the topology is posted as a PR comment for reviewer inspection"
+        isCorrect: true
+      - id: "c"
+        text: "The design is automatically deployed to production as soon as the PR is opened"
+        isCorrect: false
+      - id: "d"
+        text: "A platform engineer reviews the visual topology diff and YAML diff before approving"
+        isCorrect: true
+
+  - id: "q4"
+    text: "In Meshery's RBAC model, which built-in workspace role is appropriate for a CI pipeline or coding agent that only needs to create and modify designs in a non-production workspace?"
+    type: "single-answer"
+    marks: 2
+    explanation: "The Editor role grants all Viewer permissions plus the ability to create and modify designs - exactly the scope needed for a CI pipeline or coding agent. Admin grants unnecessary management permissions; Viewer is too restrictive; Deployer is not a built-in Meshery role."
+    options:
+      - id: "a"
+        text: "Admin"
+        isCorrect: false
+      - id: "b"
+        text: "Viewer"
+        isCorrect: false
+      - id: "c"
+        text: "Editor"
+        isCorrect: true
+      - id: "d"
+        text: "Deployer"
+        isCorrect: false
+
+  - id: "q5"
+    text: "What is the purpose of the `-s \"Kubernetes Manifest\"` flag in the `mesheryctl design import` command?"
+    type: "single-answer"
+    marks: 2
+    explanation: "The `-s` flag tells Meshery which source schema to apply when parsing the imported file. `\"Kubernetes Manifest\"` instructs Meshery to parse each document in the file by its Kubernetes `kind` and map it to a registered component in the Meshery registry."
+    options:
+      - id: "a"
+        text: "It sets the storage backend where the design will be saved"
+        isCorrect: false
+      - id: "b"
+        text: "It specifies the source schema Meshery uses to parse and map the file's contents to registered components"
+        isCorrect: true
+      - id: "c"
+        text: "It selects the Kubernetes namespace the design will be deployed into"
+        isCorrect: false
+      - id: "d"
+        text: "It authenticates the import operation against the Meshery server"
+        isCorrect: false
+
+  - id: "q6"
+    text: "Which of the following correctly describes the relationship between environments and workspaces in Meshery?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Environments are deployment targets (named groups of cluster connections). Workspaces are the access-control containers that include environments among their resources. A workspace can contain multiple environments, and environments are scoped within workspaces - not the other way around."
+    options:
+      - id: "a"
+        text: "An environment contains one or more workspaces; each workspace maps to a single cluster"
+        isCorrect: false
+      - id: "b"
+        text: "Workspaces and environments are the same concept, just named differently in different versions of Meshery"
+        isCorrect: false
+      - id: "c"
+        text: "A workspace is the access-control container that groups environments, designs, and members; environments are the deployment targets within a workspace"
+        isCorrect: true
+      - id: "d"
+        text: "Environments are created automatically when a workspace is created and cannot be managed independently"
+        isCorrect: false
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/meshery-essentials/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/meshery-essentials/_index.md
@@ -1,0 +1,16 @@
+---
+type: "course"
+id: "meshery-essentials"
+title: "2. Meshery Essentials"
+description: "Get hands-on with Meshery: install it, connect a cluster, and understand the core concepts that underpin every workflow in the academy - from visual design to AI-assisted operations."
+weight: 2
+tags: ["meshery"]
+categories: "Meshery"
+level: "beginner"
+---
+
+Meshery is the open-source cloud native manager that brings visibility, lifecycle control, configuration management, performance benchmarking, and policy governance into a single control plane. This course builds the working mental model you need before tackling any advanced topic in the academy.
+
+You will install Meshery using `mesheryctl`, connect it to a live Kubernetes cluster, and explore the registry of models, components, and relationships that makes Meshery's design validation possible. The course closes with a hands-on look at Kanvas, Meshery's visual designer, which you will use throughout the rest of the curriculum.
+
+By the end of this course you should be able to explain what Meshery does, navigate its architecture, import a design, and read a topology in Kanvas.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/meshery-essentials/orientation/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/meshery-essentials/orientation/_index.md
@@ -1,0 +1,10 @@
+---
+type: "module"
+id: "orientation"
+title: "Orientation"
+description: "Understand what Meshery is, how it is built, how to install it, and how its core concepts fit together."
+weight: 1
+tags: ["meshery"]
+categories: "Meshery"
+level: "beginner"
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/meshery-essentials/orientation/installing-meshery-and-connecting-a-cluster/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/meshery-essentials/orientation/installing-meshery-and-connecting-a-cluster/_index.md
@@ -1,0 +1,142 @@
+---
+type: "page"
+id: "installing-meshery-and-connecting-a-cluster"
+title: "Installing Meshery and Connecting a Cluster"
+description: "Install Meshery with mesheryctl, verify the deployment, connect a kubeconfig context, choose a provider, and confirm that your cluster is visible in Meshery's UI."
+weight: 3
+---
+
+## Prerequisites
+
+Before you begin, confirm you have:
+
+- `kubectl` installed and a valid kubeconfig pointing at a running Kubernetes cluster
+- Docker running locally (required if you use the default Docker-based install)
+- Go 1.21+ or a pre-built `mesheryctl` binary on your `PATH`
+
+## Installing mesheryctl
+
+`mesheryctl` is the command-line interface for Meshery. It manages the Meshery Server lifecycle and exposes every Meshery capability from the terminal.
+
+**macOS (Homebrew):**
+
+```bash
+brew install mesheryctl
+```
+
+**Linux / manual install:**
+
+```bash
+curl -L https://meshery.io/install | bash -
+```
+
+Verify the install:
+
+```bash
+mesheryctl version
+```
+
+You should see the client version printed. The server version will show as unreachable until you start Meshery.
+
+## Starting Meshery
+
+```bash
+mesheryctl system start
+```
+
+This command:
+
+1. Pulls the Meshery Server container image (or Helm chart manifests if deploying to Kubernetes).
+2. Starts the Server and its dependencies (database, Broker if running in-cluster).
+3. Opens the Meshery UI in your default browser at `http://localhost:9081`.
+
+By default, Meshery starts using Docker Compose on your local machine. For an in-cluster deployment, add `--platform kubernetes` - Meshery will deploy into the current kubeconfig context.
+
+```bash
+mesheryctl system start --platform kubernetes
+```
+
+## Verifying the Deployment
+
+```bash
+mesheryctl system check
+```
+
+`system check` runs a pre-flight inspection of your Meshery deployment. It verifies:
+
+- That the Meshery Server is reachable.
+- That the required Kubernetes permissions are available (if running in-cluster).
+- That the Meshery Operator and MeshSync are healthy in each connected cluster.
+
+A healthy output looks like:
+
+```text
+✓  Meshery Server is running
+✓  Meshery Operator is running in context: docker-desktop
+✓  MeshSync is running in context: docker-desktop
+```
+
+If any check fails, the output includes a remediation hint. Fix the indicated issue and re-run `system check` before proceeding.
+
+## Connecting a Kubeconfig Context
+
+Meshery reads your kubeconfig to discover available clusters. When you open the Meshery UI for the first time, it prompts you to select one or more kubeconfig contexts to connect.
+
+From the CLI, you can also manage connections:
+
+```bash
+mesheryctl system context list
+mesheryctl system context switch <context-name>
+```
+
+Each connected context causes Meshery to deploy the Meshery Operator and MeshSync into that cluster, beginning continuous discovery.
+
+## Choosing a Provider
+
+Meshery's **Provider** system determines where your data (designs, performance profiles, user identity) is stored and what feature set is available.
+
+| Provider | Description |
+|---|---|
+| `None` | Local only, no login, full feature set, data stored locally |
+| `Layer5` | Cloud-backed, persists data to Layer5 Cloud, enables sharing and team features |
+
+For this course, the `None` provider is sufficient. Select it on the login screen to proceed without creating an account.
+
+If you later want to collaborate on designs, share performance profiles, or participate in the Catalog, switch to the `Layer5` provider and authenticate with your Layer5 account.
+
+## Importing a Design to Verify the Connection
+
+The clearest way to confirm everything is working is to import a design and deploy it. The academy provides a microservices demo design you can use:
+
+```bash
+mesheryctl design import -f designs/microservices-demo.yaml -s "Kubernetes Manifest"
+```
+
+If the import succeeds and the design appears in the Meshery UI under **Designs**, your cluster connection is healthy. You can then deploy it from the UI or with:
+
+```bash
+mesheryctl design deploy <design-id>
+```
+
+## Stopping and Restarting
+
+```bash
+mesheryctl system stop
+mesheryctl system start
+```
+
+Meshery is stateful: your designs, connections, and performance profiles persist across restarts (they live in the database volume). A `stop` followed by `start` is safe.
+
+## Troubleshooting Common Issues
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `system check` fails on Operator | Insufficient RBAC | Ensure the kubeconfig user has `cluster-admin` or equivalent |
+| UI not reachable at port 9081 | Port conflict | Pass `--port <n>` to `mesheryctl system start` |
+| MeshSync not syncing | Broker unreachable | Check NATS pod status: `kubectl get pods -n meshery` |
+
+## Further Reading
+
+- [Getting started with Meshery](https://docs.meshery.io/installation)
+- [mesheryctl reference](https://docs.meshery.io/reference/mesheryctl)
+- [Meshery providers](https://docs.meshery.io/extensibility/providers)

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/meshery-essentials/orientation/kanvas-the-visual-designer/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/meshery-essentials/orientation/kanvas-the-visual-designer/_index.md
@@ -1,0 +1,97 @@
+---
+type: "page"
+id: "kanvas-the-visual-designer"
+title: "Kanvas: the Visual Designer"
+description: "Learn to use Kanvas - Meshery's visual designer - to visualize cluster topology, author infrastructure designs, deploy them to clusters, and explore the Catalog."
+weight: 5
+---
+
+## What Is Kanvas?
+
+Kanvas is the visual interface embedded in Meshery that lets platform engineers interact with infrastructure as diagrams rather than raw YAML. It serves two distinct but complementary purposes: **designing** infrastructure before it reaches a cluster, and **observing** infrastructure that is already running.
+
+These are surfaced as two views within Kanvas: the **Designer** and the **Operator**.
+
+## The Designer View
+
+The Designer is a canvas where you build infrastructure by placing and connecting components. Think of it as a diagram tool that is backed by a real schema: every component you drag onto the canvas is a typed Meshery component from the registry, and every connection you draw between components is a typed relationship.
+
+When you drop a `Deployment` component and a `Service` component onto the canvas and draw an edge between them, Kanvas validates that the relationship is valid (is the Service selector likely to match the Deployment's pod labels?) and flags problems as you work, not after you deploy.
+
+### Building a Design
+
+1. Open Kanvas in the Meshery UI.
+2. Select the **Designer** tab.
+3. Use the component panel on the left to search for and drag components onto the canvas. Start with a `Namespace`, then add a `Deployment` and a `Service` inside it.
+4. Draw connections between components to declare relationships.
+5. Edit component properties in the right-hand panel. Set the Deployment's label selectors and the Service's selector to match.
+6. Save the design with a name. It is now version-controlled in your Meshery instance.
+
+### Importing an Existing Design
+
+You can also import an existing YAML manifest as a Meshery design:
+
+```bash
+mesheryctl design import -f designs/microservices-demo.yaml -s "Kubernetes Manifest"
+```
+
+After import, open the design in Kanvas Designer. Meshery parses the YAML, creates the corresponding components, and attempts to infer relationships between them from the registry. The result is a diagram of your manifest with structural validation applied.
+
+Try this with the LLM gateway design as well:
+
+```bash
+mesheryctl design import -f designs/llm-mcp-gateway.yaml -s "Kubernetes Manifest"
+```
+
+Notice how the inferred relationships draw edges between the gateway components and the backing services - making the architecture immediately readable to anyone who opens the design.
+
+### Deploying a Design
+
+Once a design is ready, deploying it to a connected cluster is a single action:
+
+```bash
+mesheryctl design deploy <design-id>
+```
+
+Or use the **Deploy** button in the Kanvas UI. Meshery sends the design's components to the target cluster in dependency order, respecting the declared relationships to sequence the deployment correctly.
+
+## The Operator View
+
+The Operator view is read-only topology visualization. It shows you the live state of resources in your connected clusters as discovered by MeshSync. Unlike the Designer, which represents desired state, the Operator view represents current state.
+
+Use the Operator view to:
+
+- Confirm that a deployed design materialized as expected.
+- Spot resources that are present in the cluster but absent from any design (undocumented infrastructure, or "shadow" resources).
+- Watch topology changes propagate in real time as MeshSync reports them.
+
+Nodes in the Operator view are color-coded by health status. A red node indicates a resource in an error state; a yellow node indicates a pending or degraded state; a green node indicates healthy.
+
+## The Catalog
+
+The **Catalog** is Meshery's shared library of community-contributed designs. It contains reference architectures, integration patterns, and tested configurations that you can import into your own instance with one click and adapt for your environment.
+
+The Catalog is available in the Meshery UI under **Catalog** and at [meshery.io](https://meshery.io). When you publish a design from the Meshery UI, it becomes available to the broader community through the Catalog.
+
+The academy's importable designs (`designs/microservices-demo.yaml`, `designs/observability-stack.yaml`, `designs/llm-mcp-gateway.yaml`, `designs/policy-guardrails.yaml`) are structured the same way as Catalog entries. You can use them as local references without publishing, or publish them to the Catalog to share with the community.
+
+## Kanvas in Agentic Workflows
+
+In later modules, you will see coding agents generate designs and submit them to Meshery for validation. The Kanvas Designer is the human-readable window into that process: you can open a design that an agent produced and inspect it visually before approving deployment. This is one of the key human-in-the-loop checkpoints in AI-assisted infrastructure management.
+
+The visual graph format also makes agent-generated designs much easier to audit than raw YAML. Relationship edges surface intended connections; validation overlays surface problems. A reviewer can understand an agent's design in seconds rather than minutes.
+
+## Summary
+
+| View | Purpose | State type |
+|---|---|---|
+| Designer | Author, validate, deploy designs | Desired state |
+| Operator | Observe live topology and health | Current state |
+
+Kanvas bridges the gap between what you intend and what is running. The Designer enforces intent; the Operator reflects reality. Together they give you a complete picture of your infrastructure at any moment.
+
+## Further Reading
+
+- [Kanvas documentation](https://docs.meshery.io/kanvas)
+- [Meshery Catalog](https://meshery.io/catalog)
+- [Meshery designs documentation](https://docs.meshery.io/concepts/logical/designs)

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/meshery-essentials/orientation/meshery-architecture/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/meshery-essentials/orientation/meshery-architecture/_index.md
@@ -1,0 +1,81 @@
+---
+type: "page"
+id: "meshery-architecture"
+title: "Meshery Architecture"
+description: "Understand the components that make up a Meshery deployment - Server, Operator, MeshSync, adapters, the Broker, and Kanvas - and how discovery and state sync work across managed clusters."
+weight: 2
+---
+
+## The Two Planes
+
+Meshery's architecture divides cleanly into two planes: the **control plane** that runs Meshery itself, and the **managed clusters** that Meshery observes and operates on. Understanding this separation is essential before you install anything, because it determines where each component lives and what it is allowed to do.
+
+## Meshery Server
+
+The Meshery Server is the central brain. It exposes a REST and GraphQL API that the browser UI, `mesheryctl`, adapters, and - critically - coding agents all talk to. It maintains state in a local database (SQLite by default, PostgreSQL for production), owns the design registry, and orchestrates all lifecycle operations.
+
+The Server runs wherever you choose to host it: your laptop, a dedicated VM, or inside a Kubernetes cluster. When you run `mesheryctl system start`, the CLI bootstraps the Server (typically as a Docker container or a Kubernetes deployment) and leaves it running.
+
+## Meshery Operator
+
+The Meshery Operator is a Kubernetes operator that runs **inside each managed cluster**. It is the local agent that bridges the managed cluster back to the Meshery Server. The Operator does two things:
+
+1. It deploys and manages **MeshSync** in the cluster.
+2. It manages the **Broker** (NATS) messaging component.
+
+When you connect a cluster to Meshery, the Server pushes the Operator into that cluster via the cluster's kubeconfig.
+
+## MeshSync
+
+MeshSync is a discovery and state-sync engine. It runs as a pod inside the managed cluster and continuously watches the Kubernetes API server for changes to every resource type it knows about - Deployments, Services, ConfigMaps, CRDs from service meshes, and more. When it detects a change, it publishes a structured event to the Broker.
+
+This is how Meshery achieves real-time topology awareness without polling or scraping. MeshSync pushes; the Server subscribes.
+
+## The Broker (NATS)
+
+The Broker is a NATS messaging server that the Operator deploys alongside MeshSync. It is the communication backbone between a managed cluster and the Meshery Server. MeshSync publishes discovery events to NATS topics; the Meshery Server subscribes and updates its internal state accordingly.
+
+The NATS architecture decouples discovery from storage. If the Meshery Server restarts, it simply re-subscribes and receives the current cluster state from MeshSync's replay. This makes the system resilient to Server restarts without losing visibility.
+
+## Adapters
+
+Adapters are optional service-mesh-specific components that Meshery can connect to. Each supported service mesh - Istio, Linkerd, Consul Connect, and others - has a corresponding adapter that speaks the mesh's native API and translates operations into Meshery's unified model.
+
+Adapters are not required if you are only managing plain Kubernetes workloads. They become relevant when you need mesh-specific operations: installing a mesh, configuring traffic policies, or running mesh-specific performance tests.
+
+## Kanvas
+
+Kanvas is Meshery's visual designer and topology viewer, integrated directly into the Meshery UI. It deserves its own section in this course (Lesson 5), but architecturally it is a front-end component that reads from the Meshery Server's registry and renders designs and live topology as interactive graphs. Kanvas is where platform engineers author infrastructure visually and where operators watch live cluster state.
+
+## How Discovery and State Sync Work End-to-End
+
+The flow, from cluster resource to Meshery UI, goes like this:
+
+```text
+Kubernetes API server
+  └─► MeshSync (watches resources in the managed cluster)
+        └─► Broker / NATS (event bus in the managed cluster)
+              └─► Meshery Server (subscribes, stores in registry)
+                    └─► Kanvas / UI / API / mesheryctl
+```
+
+1. A resource changes in the managed cluster (new Deployment, updated ConfigMap, etc.).
+2. MeshSync detects the change via its watches.
+3. MeshSync publishes a structured event to the NATS Broker.
+4. The Meshery Server's subscriber receives the event and updates the internal state database.
+5. The UI (Kanvas) and API consumers reflect the updated state immediately.
+
+## Control Plane vs Managed Clusters
+
+| Location | Components |
+|---|---|
+| Control plane (where Meshery Server runs) | Meshery Server, Provider connections, Kanvas UI |
+| Each managed cluster | Meshery Operator, MeshSync, Broker (NATS), optional Adapters |
+
+A single Meshery Server can manage many clusters simultaneously. Each cluster runs its own Operator, MeshSync, and Broker. The Server aggregates all of their feeds into a unified view.
+
+## Further Reading
+
+- [Meshery architecture overview](https://docs.meshery.io/architecture)
+- [MeshSync documentation](https://docs.meshery.io/concepts/architecture/meshsync)
+- [Meshery Operator documentation](https://docs.meshery.io/concepts/architecture/operator)

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/meshery-essentials/orientation/models-components-and-relationships/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/meshery-essentials/orientation/models-components-and-relationships/_index.md
@@ -1,0 +1,84 @@
+---
+type: "page"
+id: "models-components-and-relationships"
+title: "Models, Components, and Relationships"
+description: "Understand the Meshery registry - models, components, and relationships - and how relationships enable design validation and safe AI-generated infrastructure."
+weight: 4
+---
+
+## The Registry: Meshery's Schema Layer
+
+Every infrastructure tool invents its own terminology for the same underlying concepts: resources, kinds, entities. Meshery resolves this fragmentation through a unified **registry** - a catalog of structured definitions that describes everything Meshery knows how to manage.
+
+The registry has three tiers: **Models**, **Components**, and **Relationships**.
+
+## Models
+
+A **Model** is the top-level grouping. It represents a technology domain - Kubernetes core, Istio, Prometheus, Cert-Manager, and so on. Each model is versioned and packages together all of the components and relationships that belong to that technology.
+
+When you connect a cluster and Meshery discovers an Istio installation, it loads the Istio model. The model tells Meshery what Istio resources exist, what their fields mean, and how they relate to each other and to Kubernetes resources.
+
+You can inspect loaded models from the UI under **Registry** > **Models** or from the CLI:
+
+```bash
+mesheryctl registry list
+```
+
+Models are community-maintained and distributed through the Meshery project. If a tool you care about does not have a model yet, contributing one is a direct way to extend Meshery's management capabilities.
+
+## Components
+
+A **Component** is a typed definition of a single manageable resource within a model. It maps roughly to a Kubernetes resource kind - but the concept generalizes beyond Kubernetes. Every component definition includes:
+
+- A **schema** describing its valid fields and their types.
+- A **display name** and **category** for UI presentation.
+- **Metadata** about which API group and version it belongs to.
+
+For example, the Kubernetes model contains components for `Deployment`, `Service`, `ConfigMap`, `Ingress`, and every other core API object. The Istio model contains components for `VirtualService`, `DestinationRule`, `Gateway`, and so on.
+
+When you drag a component onto the Kanvas canvas or import a design, Meshery validates the component's fields against its schema. This is the first layer of validation - structural correctness.
+
+## Relationships
+
+**Relationships** are where the registry becomes genuinely powerful. A relationship is a declared, typed connection between two components. Relationships model things like:
+
+- A `Deployment` selects `Pods` via a label selector.
+- An `Ingress` routes traffic to a `Service`.
+- A `VirtualService` applies to a `Deployment` in the same namespace.
+- A `ServiceAccount` is bound to a `ClusterRole` via a `ClusterRoleBinding`.
+
+Relationships are directional and typed. They are not inferred heuristically at runtime - they are declared in the registry by people who understand how the technologies work.
+
+### Why Relationships Enable Validation
+
+Structural schema validation (are the field names and types correct?) catches a class of errors, but not the most dangerous ones. The dangerous errors are semantic: a label selector that does not match any pod, a service port that does not align with the container port it should reach, an Istio VirtualService that references a host that has no corresponding service.
+
+These errors pass schema validation because the fields themselves are syntactically valid. They fail at runtime - often silently, often in production.
+
+Relationships enable Meshery to catch them at design time. When you build or import a design, Meshery evaluates declared relationships and flags mismatches: "this Ingress backend references a Service named `api` but no such Service exists in this design."
+
+### Relationships and AI-Generated Designs
+
+This validation layer is what makes Meshery a safe substrate for AI-generated infrastructure configurations. A coding agent constructing a Kubernetes deployment from a natural language prompt can produce syntactically valid YAML that is semantically broken - wrong selectors, missing services, port mismatches. Without a validation step, that configuration reaches the cluster and fails in opaque ways.
+
+When the agent submits the design to Meshery, relationship validation runs before deployment. Structural and semantic errors surface as structured feedback that the agent can interpret and correct - closing the loop without human intervention for the common cases.
+
+You can import the academy's observability stack design to see the registry in action:
+
+```bash
+mesheryctl design import -f designs/observability-stack.yaml -s "Kubernetes Manifest"
+```
+
+Inspect it in the Kanvas UI. Notice that relationships between components are drawn as edges in the graph - they are not decorative. Each edge represents a declared relationship from the registry, and each one is actively validated.
+
+## The Registry as a Living Catalog
+
+The registry is not static. When you connect a new cluster that has custom CRDs installed, Meshery discovers those CRDs and synthesizes component definitions for them automatically. This means the registry grows with your infrastructure: if your team installs a custom operator, its CRDs become first-class Meshery components.
+
+This extensibility is what allows Meshery to remain vendor-neutral while still providing deep, validated management for any Kubernetes-based technology.
+
+## Further Reading
+
+- [Meshery registry documentation](https://docs.meshery.io/concepts/logical/models)
+- [Meshery components](https://docs.meshery.io/concepts/logical/components)
+- [Meshery relationships](https://docs.meshery.io/concepts/logical/relationships)

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/meshery-essentials/orientation/quiz.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/meshery-essentials/orientation/quiz.md
@@ -1,0 +1,81 @@
+---
+title: "Module Quiz"
+passPercentage: 70
+type: "test"
+questions:
+  - id: "q1"
+    text: "Which Meshery component runs inside each managed Kubernetes cluster and publishes resource-change events to the Broker?"
+    type: "single-answer"
+    marks: 2
+    explanation: "MeshSync runs as a pod inside each managed cluster. It watches the Kubernetes API server and publishes structured discovery events to the NATS Broker, which the Meshery Server subscribes to."
+    options:
+      - id: "a"
+        text: "Meshery Server"
+        isCorrect: false
+      - id: "b"
+        text: "MeshSync"
+        isCorrect: true
+      - id: "c"
+        text: "Kanvas"
+        isCorrect: false
+      - id: "d"
+        text: "mesheryctl"
+        isCorrect: false
+
+  - id: "q2"
+    text: "What command verifies that Meshery Server, the Operator, and MeshSync are all healthy after installation?"
+    type: "single-answer"
+    marks: 2
+    explanation: "`mesheryctl system check` runs a pre-flight inspection that confirms Meshery Server is reachable, and that the Operator and MeshSync are running in each connected cluster."
+    options:
+      - id: "a"
+        text: "mesheryctl system start"
+        isCorrect: false
+      - id: "b"
+        text: "mesheryctl system status"
+        isCorrect: false
+      - id: "c"
+        text: "mesheryctl system check"
+        isCorrect: true
+      - id: "d"
+        text: "mesheryctl registry list"
+        isCorrect: false
+
+  - id: "q3"
+    text: "In the Meshery registry, which concept represents a declared, typed connection between two components - such as a Service selecting Pods via a label selector?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Relationships are declared, typed connections between components in the Meshery registry. They power design-time validation by checking that connections between components are semantically correct, not just syntactically valid."
+    options:
+      - id: "a"
+        text: "Model"
+        isCorrect: false
+      - id: "b"
+        text: "Component"
+        isCorrect: false
+      - id: "c"
+        text: "Relationship"
+        isCorrect: true
+      - id: "d"
+        text: "Adapter"
+        isCorrect: false
+
+  - id: "q4"
+    text: "Which two Kanvas views exist, and what does each represent?"
+    type: "multiple-answers"
+    marks: 2
+    explanation: "The Designer view represents desired state - it is where you author and validate designs before deploying them. The Operator view represents current state - it shows the live topology of resources as discovered by MeshSync."
+    options:
+      - id: "a"
+        text: "Designer - represents desired state for authoring and validating designs"
+        isCorrect: true
+      - id: "b"
+        text: "Operator - represents current state, showing live topology from MeshSync"
+        isCorrect: true
+      - id: "c"
+        text: "Auditor - represents historical state for compliance reporting"
+        isCorrect: false
+      - id: "d"
+        text: "Monitor - represents metrics state from Prometheus"
+        isCorrect: false
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/meshery-essentials/orientation/what-is-meshery/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/meshery-essentials/orientation/what-is-meshery/_index.md
@@ -1,0 +1,62 @@
+---
+type: "page"
+id: "what-is-meshery"
+title: "What Is Meshery?"
+description: "Learn what Meshery is, the problems it solves across multi-cluster environments, and where it fits relative to kubectl and other Kubernetes tools."
+weight: 1
+---
+
+## The Manager of Managers
+
+Kubernetes solved container orchestration within a single cluster. The industry then discovered that one cluster is never enough. Real production systems span multiple clusters across clouds and on-premises data centers, each running dozens of services owned by different teams, each with its own mesh, gateway, observability stack, and policy engine. Managing all of that with `kubectl` alone is like administering a city by hand-editing `/etc/hosts`.
+
+Meshery describes itself as the open-source **cloud native manager** - and specifically as a "manager of managers." It does not replace Kubernetes. It sits above it and aggregates control across every cluster, every service mesh, every cloud native tool in your estate. If you have used a cloud provider's unified management console, you have the right mental picture - except Meshery is vendor-neutral and community-governed under the [Cloud Native Computing Foundation](https://cncf.io).
+
+## What Problems Does Meshery Solve?
+
+### Visibility
+
+In a fleet of clusters, answering "what is running where?" should take seconds, not hours. Meshery continuously discovers every resource across connected clusters through its MeshSync component and surfaces them in a single UI. You can see workloads, services, configurations, and their relationships without writing a single `kubectl get` command.
+
+### Lifecycle Management
+
+Deploying an application to multiple clusters, rolling it back when something breaks, and knowing the authoritative state of a deployment at any given moment are lifecycle problems. Meshery manages Kubernetes resources as **designs** - versioned, importable, and deployable - so lifecycle operations become repeatable and auditable.
+
+### Configuration
+
+Keeping configuration consistent across clusters is one of the hardest problems in platform engineering. Drift between environments causes outages that are painful to debug. Meshery's registry of models, components, and relationships lets you validate configuration before it is applied, catching structural errors early.
+
+### Performance
+
+Knowing whether your cluster is saturated or has headroom requires continuous benchmarking. Meshery includes a performance management system, built around [Service Mesh Performance (SMP)](https://layer5.io), that runs load tests with `mesheryctl perf apply` and stores results against named profiles for trend comparison over time.
+
+### Governance
+
+Who is allowed to deploy what, and to which environments? Policy enforcement in distributed systems is notoriously fragile when it is applied ad-hoc. Meshery integrates with policy engines such as [Open Policy Agent](https://openpolicyagent.org) and enforces governance rules at design validation time, before workloads ever reach a cluster.
+
+## Where Meshery Sits Relative to kubectl
+
+`kubectl` is a single-cluster imperative tool. It is excellent for what it does: sending API requests to one Kubernetes control plane at a time. Meshery is a multi-cluster, declarative management layer that sits above the control planes.
+
+| Capability | kubectl | Meshery |
+|---|---|---|
+| Scope | Single cluster | Multi-cluster, multi-mesh |
+| Interaction model | Imperative commands | Declarative designs |
+| Topology visibility | Limited | Full, with relationships |
+| Performance benchmarking | No | Yes, via SMP |
+| Policy governance | No | Yes, with OPA integration |
+| Service mesh management | No | Yes, adapter per mesh |
+
+Importantly, Meshery does not discard `kubectl`. You still use `kubectl` for targeted, low-level operations. Meshery is the plane above it - the place where you reason about your whole infrastructure, author designs that are valid before they are applied, and let coding agents operate on real cluster state through structured APIs.
+
+## Meshery and Agentic Workflows
+
+One reason Meshery matters to this academy is that it provides the structured interface that coding agents need to act on infrastructure reliably. A language model given raw `kubectl` access and an untyped YAML file faces enormous ambiguity. Meshery's registry - with typed components and declared relationships - gives an agent a schema to reason against, a validation step to catch hallucinated configurations, and a set of discrete operations (deploy, undeploy, validate, benchmark) that map naturally to tool calls.
+
+You will explore this connection in depth later in the curriculum. For now, understand that Meshery's design as a structured manager is also what makes it a safe, auditable substrate for AI-assisted operations.
+
+## Further Reading
+
+- [Meshery project overview](https://meshery.io)
+- [Meshery documentation](https://docs.meshery.io)
+- [CNCF landscape entry](https://landscape.cncf.io)

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/meshery-essentials/test.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/foundations-of-cloud-native-management-with-meshery/meshery-essentials/test.md
@@ -1,0 +1,119 @@
+---
+title: "Course Test"
+passPercentage: 70
+type: "test"
+questions:
+  - id: "q1"
+    text: "Meshery is best described as which of the following?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Meshery is the open-source cloud native manager - sometimes called a 'manager of managers' - that provides visibility, lifecycle management, configuration, performance benchmarking, and governance across multiple clusters and service meshes from a single control plane."
+    options:
+      - id: "a"
+        text: "A replacement for kubectl that manages a single cluster"
+        isCorrect: false
+      - id: "b"
+        text: "An open-source cloud native manager that operates across multiple clusters and service meshes"
+        isCorrect: true
+      - id: "c"
+        text: "A service mesh that handles traffic routing between microservices"
+        isCorrect: false
+      - id: "d"
+        text: "A CI/CD pipeline tool for Kubernetes deployments"
+        isCorrect: false
+
+  - id: "q2"
+    text: "Which components run inside each managed cluster as part of the Meshery architecture? Select all that apply."
+    type: "multiple-answers"
+    marks: 2
+    explanation: "The Meshery Operator, MeshSync, and the NATS Broker all run inside each managed cluster. The Meshery Server runs in the control plane, not in the managed clusters."
+    options:
+      - id: "a"
+        text: "Meshery Operator"
+        isCorrect: true
+      - id: "b"
+        text: "MeshSync"
+        isCorrect: true
+      - id: "c"
+        text: "Broker (NATS)"
+        isCorrect: true
+      - id: "d"
+        text: "Meshery Server"
+        isCorrect: false
+
+  - id: "q3"
+    text: "What is the correct command to start Meshery on your local machine using the default Docker-based deployment?"
+    type: "single-answer"
+    marks: 2
+    explanation: "`mesheryctl system start` bootstraps the Meshery Server using Docker Compose by default. Adding `--platform kubernetes` deploys it into the current kubeconfig context instead."
+    options:
+      - id: "a"
+        text: "mesheryctl start"
+        isCorrect: false
+      - id: "b"
+        text: "mesheryctl system start"
+        isCorrect: true
+      - id: "c"
+        text: "mesheryctl deploy --local"
+        isCorrect: false
+      - id: "d"
+        text: "mesheryctl server up"
+        isCorrect: false
+
+  - id: "q4"
+    text: "What command would you use to import the academy's microservices demo design into Meshery?"
+    type: "single-answer"
+    marks: 2
+    explanation: "`mesheryctl design import -f <file> -s \"Kubernetes Manifest\"` imports a YAML manifest as a Meshery design. The `-s` flag specifies the source type."
+    options:
+      - id: "a"
+        text: "mesheryctl design load designs/microservices-demo.yaml"
+        isCorrect: false
+      - id: "b"
+        text: "mesheryctl apply -f designs/microservices-demo.yaml"
+        isCorrect: false
+      - id: "c"
+        text: "mesheryctl design import -f designs/microservices-demo.yaml -s \"Kubernetes Manifest\""
+        isCorrect: true
+      - id: "d"
+        text: "kubectl apply -f designs/microservices-demo.yaml"
+        isCorrect: false
+
+  - id: "q5"
+    text: "In the Meshery registry, what is the role of a Model?"
+    type: "single-answer"
+    marks: 2
+    explanation: "A Model is the top-level grouping in the Meshery registry. It represents a technology domain - such as Kubernetes core, Istio, or Prometheus - and packages together all of the components and relationships that belong to that technology."
+    options:
+      - id: "a"
+        text: "A single manageable resource, equivalent to a Kubernetes resource kind"
+        isCorrect: false
+      - id: "b"
+        text: "A declared, typed connection between two components"
+        isCorrect: false
+      - id: "c"
+        text: "A top-level grouping for a technology domain, containing its components and relationships"
+        isCorrect: true
+      - id: "d"
+        text: "A versioned snapshot of a deployed cluster state"
+        isCorrect: false
+
+  - id: "q6"
+    text: "How does the Kanvas Operator view differ from the Kanvas Designer view?"
+    type: "single-answer"
+    marks: 2
+    explanation: "The Operator view shows the live current state of resources in connected clusters as discovered by MeshSync. The Designer view shows desired state - it is where you author, validate, and prepare designs for deployment."
+    options:
+      - id: "a"
+        text: "The Operator view is for authoring designs; the Designer view is for reading live cluster state"
+        isCorrect: false
+      - id: "b"
+        text: "The Operator view shows live current state from MeshSync; the Designer view represents desired state for authoring designs"
+        isCorrect: true
+      - id: "c"
+        text: "They are identical views with different color themes"
+        isCorrect: false
+      - id: "d"
+        text: "The Operator view requires cluster-admin access; the Designer view does not"
+        isCorrect: false
+---


### PR DESCRIPTION
## TCS Labs Academy — PR 2: Learning Paths 1 & 2 (full content)

Second in the phased series. Adds the first two learning paths in full - every course, module,
lesson, quiz, test, and path exam.

> **Stacked on [#12](https://github.com/meshery-extensions/tcslabs-academy/pull/12)** (foundation).
> Base is `feat/academy-foundation` so CI builds with the Hugo scaffolding present. GitHub will
> retarget this PR to `master` automatically once #12 merges.

### Learning Path 1 — Foundations of Cloud Native Management with Meshery *(beginner)*

| Course | Lessons |
|--------|---------|
| Cloud Native & Kubernetes Essentials | what is cloud native · containers & images · Kubernetes essentials · declarative infra & GitOps |
| Meshery Essentials | what is Meshery · architecture · installing & connecting a cluster · models/components/relationships · Kanvas |
| Infrastructure as Designs | authoring your first design · the Catalog · designs-as-code with GitHub · environments & workspaces |

### Learning Path 2 — AI Engineering Foundations for Platform Engineers *(beginner–intermediate)*

| Course | Lessons |
|--------|---------|
| How LLMs Work for Infrastructure Engineers | what is an LLM · tokens/context/limits · strengths & failure modes · choosing a model |
| Prompt Engineering for Cloud Native Operations | system/user instructions · grounding in infra state · structured output · prompt patterns · evaluating prompts |
| Coding Agents 101 | what is a coding agent · the agentic loop & tool use · agents for infrastructure · human-in-the-loop |
| Retrieval & Context (RAG) for Infrastructure | why agents need context · grounding in cluster/Meshery state · building a knowledge base · evaluating agents |

### By the numbers

- **30 lessons** (~23.5k words), **7 module quizzes**, **7 course tests**, **2 path exams**.
- LLMs and coding agents are taught **vendor-neutrally**; every Meshery command/concept is real
  (`mesheryctl`, Kanvas, MeshSync, models/relationships, designs, the Catalog).

### Verification

- `hugo --gc --minify --buildDrafts --buildFuture` → **exit 0, 0 errors, 169 pages** (hugo 0.163 extended).
- Style scan: **no em-dashes**, **no commercial AI-vendor links** in the new content.
- Content-ID registry messages are *warnings* (expected until ids are registered via the Cloud
  content wizard).

### Next

PR 3 — Learning Path 3 (flagship: AI-Assisted Infrastructure Design with Meshery & Kanvas).
