### PR TITLE
TCS Labs Academy - PR 3: Learning Path 3 (flagship) - AI-Assisted Infrastructure Design

### DIFF
--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/_index.md
@@ -1,0 +1,9 @@
+---
+type: "learning-path"
+title: "AI-Assisted Infrastructure Design with Meshery & Kanvas"
+description: "The flagship path. Go from plain-language intent to a deployed, validated Meshery design - generating infrastructure with LLMs, co-designing in Kanvas, deploying with a coding agent, and validating every change before it ships."
+id: "5d26d3ec-ddfb-46f7-9684-b56e9b567564"
+banner: "banner.svg"
+weight: 3
+level: "intermediate"
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/agent-driven-deployment/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/agent-driven-deployment/_index.md
@@ -1,0 +1,16 @@
+---
+type: "course"
+id: "agent-driven-deployment"
+title: "3. Agent-Driven Deployment"
+description: "Learn how to close the loop between AI-generated infrastructure designs and live clusters by having a coding agent drive the deploy pipeline through mesheryctl and GitOps tooling."
+weight: 3
+tags: ["ai","agents","gitops"]
+categories: "AI"
+level: "intermediate"
+---
+
+Platform engineers rarely deploy by hand anymore - the same coding agents that generate and refine a Meshery design can also commit that design to Git, run a dry-run diff, and push it to a cluster once a human approves the output. This course walks through every stage of that loop with concrete commands and realistic scenarios.
+
+You will learn how to wire an agent into a GitOps pipeline so that `mesheryctl` is the enforced execution path, how to read a dry-run diff and reason about blast radius before applying anything, and how to recover cleanly when a deployment goes wrong. The four lessons move in order from architecture to practice: the big-picture loop, safe preview workflows, a hands-on deployment walkthrough, and finally rollback and recovery.
+
+By the end of this course you can instruct an agent to deploy `designs/microservices-demo.yaml`, verify the rollout, and revert it - all with a reproducible, auditable trail in Git.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/agent-driven-deployment/deploying-with-agents/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/agent-driven-deployment/deploying-with-agents/_index.md
@@ -1,0 +1,10 @@
+---
+type: "module"
+id: "deploying-with-agents"
+title: "Deploying with Agents"
+description: "Close the loop from AI-generated design to live cluster using mesheryctl, GitOps, and human-in-the-loop checkpoints."
+weight: 1
+tags: ["gitops"]
+categories: "AI"
+level: "intermediate"
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/agent-driven-deployment/deploying-with-agents/deploying-a-design-with-an-agent/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/agent-driven-deployment/deploying-with-agents/deploying-a-design-with-an-agent/_index.md
@@ -1,0 +1,144 @@
+---
+type: "page"
+id: "deploying-a-design-with-an-agent"
+title: "Deploying a Design with an Agent"
+description: "A concrete walkthrough: an agent imports and deploys designs/microservices-demo.yaml through Meshery, then verifies the rollout with kubectl and mesheryctl."
+weight: 3
+---
+
+## The Scenario
+
+You have an updated `designs/microservices-demo.yaml` in your Git repository. A previous lesson covered how the agent generated and reviewed this design in Kanvas. Now the human reviewer has approved it. The task: have an agent drive the import, deploy, and verification sequence through Meshery.
+
+This lesson is a step-by-step walkthrough. Each shell block is a real command the agent issues, with the expected output and the reasoning behind it.
+
+## Prerequisites
+
+Before the agent begins, confirm the environment is ready:
+
+```bash
+mesheryctl system check
+```
+
+Expected output includes lines similar to:
+
+```text
+✓ mesheryctl version: v0.7.x
+✓ Meshery Server: reachable at http://localhost:9081
+✓ Kubernetes: context "prod-west" active, server reachable
+✓ Meshery Operator: running in namespace meshery
+✓ MeshSync: running and syncing
+```
+
+If any check fails, stop. A partial environment will produce a partial deploy and leave the cluster in an inconsistent state.
+
+## Step 1 - Import the Design
+
+```bash
+mesheryctl design import -f designs/microservices-demo.yaml -s "Kubernetes Manifest"
+```
+
+This command uploads the file to Meshery Server, which parses it into a named Meshery design. The `-s "Kubernetes Manifest"` flag tells Meshery which source schema to apply during import. On success you will see:
+
+```text
+Design imported successfully.
+Design ID: <uuid>
+Design Name: microservices-demo
+```
+
+Record the Design ID. The agent should store it for subsequent commands in this session.
+
+## Step 2 - Verify the Import in Meshery
+
+After import, open Kanvas or query via CLI to confirm the design topology is correct before deploying. You can list designs with:
+
+```bash
+mesheryctl design list
+```
+
+Look for `microservices-demo` in the output. If you have the Kanvas UI open, you can visually inspect the topology at this point - components, relationships, and any validation warnings the import surfaced.
+
+This is a lightweight human check. You are not re-reviewing the design in detail; you are confirming the import succeeded and the design is the one you intended.
+
+## Step 3 - Dry-Run
+
+Apply the dry-run technique from the previous lesson:
+
+```bash
+kubectl apply -f designs/microservices-demo.yaml --dry-run=server
+kubectl diff -f designs/microservices-demo.yaml
+```
+
+The agent should surface the diff output and any blast-radius assessment before proceeding. In this walkthrough, assume the diff shows:
+
+```text
+-   image: ghcr.io/org/frontend:v1.3
++   image: ghcr.io/org/frontend:v1.4
+
+-   replicas: 2
++   replicas: 3
+```
+
+Blast radius: medium - one image update plus a scale-up. The agent reports this and waits for approval.
+
+## Step 4 - Deploy via Meshery
+
+Once approved, the agent deploys the design. In a direct `mesheryctl` workflow this is currently handled by applying the manifest through `kubectl` after the Meshery design is registered:
+
+```bash
+kubectl apply -f designs/microservices-demo.yaml
+```
+
+Meshery's MeshSync will pick up the resulting cluster state change within its sync interval and update the design's live status in the Meshery dashboard.
+
+## Step 5 - Verify the Rollout
+
+The agent monitors rollout progress:
+
+```bash
+kubectl rollout status deployment/frontend -n microservices-demo
+kubectl rollout status deployment/api-gateway -n microservices-demo
+```
+
+Expected output when rollout completes:
+
+```text
+deployment "frontend" successfully rolled out
+deployment "api-gateway" successfully rolled out
+```
+
+Then confirm all pods are healthy:
+
+```bash
+kubectl get pods -n microservices-demo
+```
+
+Every pod in the namespace should show `Running` with `READY` equal to the container count. Any pod stuck in `Pending`, `CrashLoopBackOff`, or `ImagePullBackOff` is a signal to investigate before declaring success.
+
+## Step 6 - Confirm via mesheryctl
+
+```bash
+mesheryctl system check
+```
+
+A clean check after apply confirms that Meshery Server, MeshSync, and the Operator are all still healthy and that the deploy did not destabilize the Meshery control plane.
+
+## What the Agent Records
+
+At the end of this sequence the agent should record:
+
+- The commit hash of `designs/microservices-demo.yaml` that was deployed.
+- The Meshery Design ID.
+- The timestamp and Kubernetes context used.
+- The rollout status for each Deployment.
+
+This information is what makes rollback deterministic. If something goes wrong in the next hour, the agent - or the on-call engineer - can go directly to these values and revert the exact change.
+
+## Common Problems at This Stage
+
+| Problem | Likely cause | Action |
+|---|---|---|
+| `ImagePullBackOff` | Image tag does not exist in the registry | Fix the image reference in the design, re-import |
+| `Pending` pods | Insufficient cluster resources | Scale the cluster or reduce replica count |
+| `mesheryctl` import fails | Meshery Server not reachable | Run `mesheryctl system check`, restart if needed |
+| `kubectl diff` shows unexpected deletions | Stale resources in namespace not in design | Review namespace contents before apply |

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/agent-driven-deployment/deploying-with-agents/dry-runs-and-diffs/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/agent-driven-deployment/deploying-with-agents/dry-runs-and-diffs/_index.md
@@ -1,0 +1,96 @@
+---
+type: "page"
+id: "dry-runs-and-diffs"
+title: "Dry-Runs and Diffs"
+description: "Always preview before applying: how to run a dry-run, read the diff, assess blast radius, and have the agent wait for explicit approval."
+weight: 2
+---
+
+## The Cost of Skipping Preview
+
+An agent that deploys without preview is indistinguishable from a runaway script. The dry-run step is where human judgment re-enters the loop. It is not optional, it is not a courtesy - it is the control mechanism that separates an agentic workflow from an autonomous one.
+
+This lesson gives you the mechanics and the reading skills to use dry-runs effectively.
+
+## What a Dry-Run Does
+
+A dry-run submits the intended change to the Kubernetes API server with `--dry-run=client` or `--dry-run=server` without persisting anything. The server validates the manifest against the current schema and admission webhooks and returns either a success response or a structured error. No pods are created, no services are updated.
+
+The diff step goes further: it compares the current cluster state against the incoming manifest and reports exactly which fields will change. This is where you see blast radius.
+
+## Running a Dry-Run
+
+For a raw Kubernetes manifest, your agent can invoke:
+
+```bash
+kubectl apply -f designs/microservices-demo.yaml --dry-run=server
+```
+
+Server-side dry-run passes through admission webhooks and gives a more accurate result than client-side. If you are running a policy layer such as OPA/Gatekeeper, server-side dry-run is the only mode that exercises those policies.
+
+For Meshery designs, import the file and use Meshery's validation layer:
+
+```bash
+mesheryctl design import -f designs/microservices-demo.yaml -s "Kubernetes Manifest"
+```
+
+After import, use `mesheryctl system check` to confirm connectivity before proceeding.
+
+## Reading the Diff
+
+`kubectl diff` is the canonical tool for showing what will change:
+
+```bash
+kubectl diff -f designs/microservices-demo.yaml
+```
+
+The output uses standard unified-diff format. Lines beginning with `-` are what exists today; lines beginning with `+` are what will exist after apply.
+
+Key things to look for in the diff:
+
+| Signal | What it means |
+|---|---|
+| Image tag changes | A rollout will be triggered for every affected Deployment |
+| Resource limit changes | Pods will be evicted if new limits are lower than current usage |
+| Label selector changes | The old ReplicaSet is orphaned - manual cleanup required |
+| New Namespace | A new namespace will be created; RBAC may not be ready |
+| Deleted resources | Anything removed from the manifest will be deleted from the cluster |
+
+## Assessing Blast Radius
+
+Blast radius is the scope of potential impact if the change has an unexpected side effect. A useful heuristic:
+
+- **Low blast radius**: changes isolated to a single Deployment's environment variables or config map data, no selector changes, same replica count.
+- **Medium blast radius**: image tag rollout across multiple Deployments, new Service or Ingress resources.
+- **High blast radius**: changes to label selectors, Namespace deletions, or PersistentVolumeClaim modifications.
+
+Train your agent to categorize blast radius explicitly and surface the category in its approval request. An agent that just says "ready to apply" is not useful. An agent that says "medium blast radius - rolling update of 3 Deployments across the `payments` namespace, no selector changes, estimated rollout time 90 seconds" gives you the information you need to approve or pause.
+
+## The Approval Checkpoint
+
+The agent must not proceed from diff to apply without a discrete signal from a human or a policy gate. Implement this as a function call with a boolean result:
+
+```text
+[Agent]: Dry-run passed. Diff summary:
+  - frontend: image updated ghcr.io/org/frontend:v1.3 -> v1.4
+  - api-gateway: replicas 2 -> 3
+  Blast radius: medium. Estimated rollout: 60s.
+  Approve apply? [yes/no]
+
+[Human]: yes
+
+[Agent]: Calling mesheryctl design import ...
+```
+
+If the agent is running unattended in a CI pipeline, the policy gate can be an OPA policy evaluated against the diff JSON. See [openpolicyagent.org](https://openpolicyagent.org) for policy authoring guidance.
+
+## Handling Dry-Run Failures
+
+When `kubectl apply --dry-run=server` returns a non-zero exit code, the agent should:
+
+1. Parse the error message - most API server errors include the field path and the constraint violated.
+2. Attempt to fix the manifest if the error is structural (missing required field, invalid value).
+3. Re-run the dry-run after the fix.
+4. If the error is policy-driven (admission webhook rejection), surface the policy name and escalate to a human - do not attempt to work around policy.
+
+A dry-run failure is not a deployment failure. Nothing in the cluster changed. It is a signal to revise the design before proceeding.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/agent-driven-deployment/deploying-with-agents/quiz.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/agent-driven-deployment/deploying-with-agents/quiz.md
@@ -1,0 +1,78 @@
+---
+title: "Module Quiz"
+passPercentage: 70
+type: "test"
+questions:
+  - id: "q1"
+    text: "In the agent deploy loop, at what point must the design be committed to Git?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Git must be committed before any apply step so that the source of truth is updated before cluster state changes. The dry-run and apply both happen after the commit."
+    options:
+      - id: "a"
+        text: "After the dry-run passes and human approval is granted"
+        isCorrect: false
+      - id: "b"
+        text: "Before the dry-run, as soon as the design file is ready"
+        isCorrect: true
+      - id: "c"
+        text: "After the deploy completes successfully"
+        isCorrect: false
+      - id: "d"
+        text: "Git commit is optional if mesheryctl is used directly"
+        isCorrect: false
+  - id: "q2"
+    text: "Which kubectl flag should be preferred for a dry-run because it passes through admission webhooks and OPA/Gatekeeper policies?"
+    type: "single-answer"
+    marks: 2
+    explanation: "--dry-run=server sends the request to the API server, which exercises admission webhooks and policy checks. --dry-run=client validates only client-side and does not exercise server-side policies."
+    options:
+      - id: "a"
+        text: "--dry-run=client"
+        isCorrect: false
+      - id: "b"
+        text: "--dry-run=server"
+        isCorrect: true
+      - id: "c"
+        text: "--validate=true"
+        isCorrect: false
+      - id: "d"
+        text: "--force"
+        isCorrect: false
+  - id: "q3"
+    text: "What does MeshSync do after a design is deployed to the cluster?"
+    type: "single-answer"
+    marks: 2
+    explanation: "MeshSync continuously observes cluster state and reports it back to Meshery Server. This is how Meshery knows whether the live cluster matches the intended design."
+    options:
+      - id: "a"
+        text: "It generates a new design YAML from current cluster state"
+        isCorrect: false
+      - id: "b"
+        text: "It applies the design to the cluster on a schedule"
+        isCorrect: false
+      - id: "c"
+        text: "It continuously reconciles observed cluster state with Meshery's design view"
+        isCorrect: true
+      - id: "d"
+        text: "It pushes design changes back to the Git repository"
+        isCorrect: false
+  - id: "q4"
+    text: "When rolling back a failed deploy in a GitOps workflow, which of the following actions are part of the correct procedure?"
+    type: "multiple-answers"
+    marks: 3
+    explanation: "The correct rollback sequence is: use kubectl rollout undo as an emergency stop, then revert the Git commit to restore the source of truth, then re-apply the reverted design so Git, Meshery, and the cluster are all aligned."
+    options:
+      - id: "a"
+        text: "Run kubectl rollout undo as an emergency stop to restore the previous ReplicaSet"
+        isCorrect: true
+      - id: "b"
+        text: "Revert the broken commit in Git with git revert"
+        isCorrect: true
+      - id: "c"
+        text: "Re-import and re-apply the reverted design via mesheryctl and kubectl"
+        isCorrect: true
+      - id: "d"
+        text: "Skip the dry-run on the retry to save time"
+        isCorrect: false
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/agent-driven-deployment/deploying-with-agents/rollback-and-recovery/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/agent-driven-deployment/deploying-with-agents/rollback-and-recovery/_index.md
@@ -1,0 +1,118 @@
+---
+type: "page"
+id: "rollback-and-recovery"
+title: "Rollback and Recovery"
+description: "When a deploy goes wrong: rolling back via Git revert and Meshery, confirming recovery, and capturing what happened."
+weight: 4
+---
+
+## When to Roll Back
+
+Not every post-deploy anomaly requires a rollback. A single pod restarting once is not a rollback trigger. A sustained error rate increase, a service that is not reachable, or a deployment stuck in progress for longer than the expected rollout time - those are rollback triggers.
+
+Define the threshold before you deploy, not during the incident. Tell your agent: "If the rollout does not complete within 3 minutes, or if error rate on `/api/orders` rises above 1% within 5 minutes of apply, initiate rollback." Pre-defined thresholds let the agent act without waiting for a human to notice something is wrong.
+
+## The Rollback Strategy
+
+The safest rollback path in a GitOps workflow is a Git revert followed by a re-apply. This approach keeps Git as the source of truth and leaves a complete audit trail - you can see both the broken commit and the revert commit in the log.
+
+Do not use `kubectl rollout undo` as the primary mechanism if your design lives in Git. `kubectl rollout undo` rolls back the Deployment in the cluster but does not update the Git file, creating a gap between Git state and cluster state. Use it only as an emergency stop while you prepare the Git revert.
+
+## Step 1 - Stop the Bleeding (if needed)
+
+If pods are crashing and traffic is being affected, roll back the Kubernetes Deployment immediately:
+
+```bash
+kubectl rollout undo deployment/frontend -n microservices-demo
+kubectl rollout undo deployment/api-gateway -n microservices-demo
+```
+
+This restores the previous ReplicaSet instantly. Confirm recovery:
+
+```bash
+kubectl rollout status deployment/frontend -n microservices-demo
+kubectl get pods -n microservices-demo
+```
+
+This buys time. Git and Meshery still think the new version is deployed - fix that in the next steps.
+
+## Step 2 - Revert in Git
+
+Identify the commit that introduced the broken design:
+
+```bash
+git log --oneline designs/microservices-demo.yaml
+```
+
+Revert it:
+
+```bash
+git revert <commit-hash> --no-edit
+git push origin main
+```
+
+The revert commit restores `designs/microservices-demo.yaml` to its previous state. The commit message should reference the incident: `revert: rollback microservices-demo - elevated error rate post v1.4 deploy`.
+
+## Step 3 - Re-apply the Reverted Design via Meshery
+
+With the reverted file in Git, re-import and re-apply:
+
+```bash
+mesheryctl design import -f designs/microservices-demo.yaml -s "Kubernetes Manifest"
+kubectl apply -f designs/microservices-demo.yaml
+```
+
+This brings cluster state, Git state, and Meshery design state back into alignment. Run the same verification sequence from the deployment lesson:
+
+```bash
+kubectl rollout status deployment/frontend -n microservices-demo
+kubectl get pods -n microservices-demo
+mesheryctl system check
+```
+
+## Step 4 - Confirm Recovery
+
+Recovery is confirmed when:
+
+- All pods show `Running` with full readiness.
+- The rollout status reports `successfully rolled out` for each Deployment.
+- Application-level health checks pass (endpoint probes, smoke tests, or whatever your team uses).
+- `mesheryctl system check` reports all components healthy.
+
+The agent should run all four checks and report results before declaring recovery complete. "Looks good" is not a confirmation. A complete confirmation looks like:
+
+```text
+Recovery confirmed:
+  - frontend: 3/3 pods Running, rollout complete
+  - api-gateway: 2/2 pods Running, rollout complete
+  - mesheryctl system check: all components healthy
+  - Smoke test /api/orders: HTTP 200, p99 latency 45ms
+  Git revert commit: abc1234
+```
+
+## Step 5 - Capture What Happened
+
+A rollback without a post-incident record is a missed learning opportunity. Have the agent produce a brief structured summary immediately after recovery:
+
+| Field | Content |
+|---|---|
+| Broken commit | The SHA that was reverted |
+| Revert commit | The SHA that restored the previous state |
+| Time to detect | When the problem was first observed |
+| Time to recover | When recovery was confirmed |
+| Root cause (initial) | What the diff showed that likely caused the problem |
+| Follow-up | What needs investigation before the change is re-attempted |
+
+This summary belongs in the pull request that introduced the broken change, as a comment. Future readers - human and agent - can find the context there.
+
+## Re-trying After a Rollback
+
+A rollback is not the end of the deploy. It is the start of a diagnosis cycle. The agent can help: given the diff from the broken change and the error signals, it can reason about the likely cause and propose a revised design.
+
+When you are ready to retry, go back to the dry-run lesson and treat the retry as a new deployment. Do not skip the dry-run because you are in a hurry to restore the feature - the dry-run is exactly what catches the subtle error you introduced in the fix.
+
+## Meshery and MeshSync During Rollback
+
+MeshSync continuously observes cluster state. After a `kubectl rollout undo` and then a `kubectl apply` of the reverted design, MeshSync will update Meshery's view of the cluster within its sync interval (typically seconds). You can watch the Meshery dashboard update in near real time, which is useful for confirming that the cluster state Meshery sees matches what you intend.
+
+If Meshery's design view does not update after a few minutes, run `mesheryctl system check` to confirm MeshSync is still healthy. A crashed MeshSync will not surface the updated cluster state.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/agent-driven-deployment/deploying-with-agents/the-deploy-loop-agent-mesheryctl-gitops/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/agent-driven-deployment/deploying-with-agents/the-deploy-loop-agent-mesheryctl-gitops/_index.md
@@ -1,0 +1,105 @@
+---
+type: "page"
+id: "the-deploy-loop-agent-mesheryctl-gitops"
+title: "The Deploy Loop: Agent + mesheryctl + GitOps"
+description: "Understand the end-to-end loop connecting an AI agent, a Git repository, and mesheryctl to produce auditable, reproducible cluster deployments."
+weight: 1
+---
+
+## Why a Loop, Not a Script
+
+A one-shot deploy script answers only the question in front of it. An agentic deploy loop answers a class of questions: it can regenerate a design when requirements change, catch a failed health check and retry with a modified configuration, and leave a readable commit trail behind every change. The difference between a script and a loop is that the loop can reason.
+
+This lesson maps the architecture of that loop so you can see where each tool fits - and where the human-in-the-loop checkpoint must sit.
+
+## The Four Stages
+
+### 1. Generate or Edit the Design
+
+Your agent starts in Meshery's design workspace. It can generate a new design from a natural-language prompt (using the Meshery Kanvas design API or MCP tooling) or load an existing design file such as `designs/microservices-demo.yaml` and patch it to match updated requirements.
+
+The agent outputs a valid Meshery design - either as a YAML file or directly registered in Meshery under a named design. At this stage nothing has touched a cluster.
+
+### 2. Commit to Git
+
+Once the design YAML is ready, the agent commits it to the infrastructure Git repository. This step is non-negotiable. Git is the source of truth; the file must be versioned before it is deployed.
+
+A minimal commit workflow:
+
+```bash
+git add designs/microservices-demo.yaml
+git commit -m "chore: update microservices-demo for release-1.4 rollout"
+git push origin main
+```
+
+The agent should write a commit message that references the intent it was given - this creates a human-readable audit trail that does not depend on reconstructing agent context later.
+
+### 3. Preview - Do Not Skip
+
+Before applying, the agent runs a dry-run. See the next lesson for the full dry-run workflow. The important architectural point here is that the dry-run happens **between commit and apply** - the design is already in Git, but no cluster state has changed. This is the human checkpoint.
+
+### 4. Apply via mesheryctl
+
+After a human (or a policy gate) approves the diff, the agent calls `mesheryctl` to import and deploy:
+
+```bash
+mesheryctl design import -f designs/microservices-demo.yaml -s "Kubernetes Manifest"
+```
+
+`mesheryctl` communicates with the Meshery server, which in turn drives MeshSync and the Meshery Operator to reconcile cluster state.
+
+## How the Pieces Connect
+
+```text
+Agent (LLM + tools)
+  |
+  |-- generates/edits design YAML
+  |
+  v
+Git repository  <-- single source of truth
+  |
+  |-- dry-run diff (human reviews)
+  |
+  v
+mesheryctl design import
+  |
+  v
+Meshery Server
+  |
+  +-- Meshery Operator  -->  cluster resources
+  |
+  +-- MeshSync          -->  discovery / drift detection
+```
+
+MeshSync continuously reconciles what is in the cluster against what Meshery expects. If an agent deploys a design and MeshSync later detects drift, that signal can feed back to the agent as a new task: reconcile the drift.
+
+## GitOps Integration
+
+If your organization runs a GitOps controller (Argo CD, Flux), the agent can target the same Git repository that the controller watches. In that model:
+
+- The agent writes and commits the design YAML.
+- The GitOps controller picks up the commit and drives the reconcile loop.
+- `mesheryctl` is used for health checks and Meshery-specific operations (`mesheryctl system check`) rather than as the primary apply mechanism.
+
+Both models - direct `mesheryctl` apply and GitOps controller - are valid. The key invariant is the same: **Git is committed before anything reaches the cluster**, and the diff is reviewed before apply.
+
+## Context Window and Tool Budget
+
+An agentic loop that spans generate, commit, preview, and apply makes many tool calls. Agents with a limited context window can lose track of the original intent by the time they reach the apply step. Mitigate this by:
+
+- Writing the intent to a file at the start of the session and having the agent re-read it before apply.
+- Keeping each step atomic - generate, commit, preview, apply as separate, logged calls.
+- Using structured output at each stage so the next stage has a clean input rather than free-form text.
+
+## Verify the Loop is Healthy
+
+After `mesheryctl` returns, verify with:
+
+```bash
+mesheryctl system check
+kubectl get pods -n <target-namespace>
+```
+
+A passing `mesheryctl system check` confirms Meshery Server, MeshSync, and the Operator are all reachable. The `kubectl` check confirms the workloads the design specified are actually running.
+
+The loop closes here: if the verification passes, the agent can mark the task complete and record the commit hash as the deployed version. If it fails, the rollback lesson covers the next step.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/agent-driven-deployment/test.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/agent-driven-deployment/test.md
@@ -1,0 +1,114 @@
+---
+title: "Course Test"
+passPercentage: 70
+type: "test"
+questions:
+  - id: "q1"
+    text: "What is the correct mesheryctl command to import a Kubernetes manifest file named designs/microservices-demo.yaml?"
+    type: "single-answer"
+    marks: 2
+    explanation: "The -f flag specifies the file path and the -s flag specifies the source schema type. 'Kubernetes Manifest' is the correct schema identifier for raw Kubernetes YAML files."
+    options:
+      - id: "a"
+        text: "mesheryctl design apply -f designs/microservices-demo.yaml"
+        isCorrect: false
+      - id: "b"
+        text: "mesheryctl design import -f designs/microservices-demo.yaml -s \"Kubernetes Manifest\""
+        isCorrect: true
+      - id: "c"
+        text: "mesheryctl system import designs/microservices-demo.yaml"
+        isCorrect: false
+      - id: "d"
+        text: "mesheryctl design upload --file designs/microservices-demo.yaml"
+        isCorrect: false
+  - id: "q2"
+    text: "In the agent deploy loop, the human-in-the-loop checkpoint occurs between which two stages?"
+    type: "single-answer"
+    marks: 2
+    explanation: "The human reviews the dry-run diff after the design has been committed to Git but before any apply command is run. This preserves the audit trail in Git while preventing unapproved changes from reaching the cluster."
+    options:
+      - id: "a"
+        text: "Between design generation and Git commit"
+        isCorrect: false
+      - id: "b"
+        text: "Between Git commit and cluster apply, during the dry-run review"
+        isCorrect: true
+      - id: "c"
+        text: "After cluster apply, during rollout monitoring"
+        isCorrect: false
+      - id: "d"
+        text: "Before design generation, as a requirements sign-off"
+        isCorrect: false
+  - id: "q3"
+    text: "Which of the following conditions should an agent use as pre-defined rollback triggers?"
+    type: "multiple-answers"
+    marks: 3
+    explanation: "Pre-defined rollback triggers should be objective and measurable: a rollout that exceeds its expected time window and an application error rate that rises above a defined threshold are both clear signals. A single pod restart and a Pending pod on a new node are normal transient conditions that do not require rollback."
+    options:
+      - id: "a"
+        text: "Rollout does not complete within the expected time window"
+        isCorrect: true
+      - id: "b"
+        text: "Application error rate rises above the defined threshold shortly after apply"
+        isCorrect: true
+      - id: "c"
+        text: "A single pod restarts once during the rollout"
+        isCorrect: false
+      - id: "d"
+        text: "One pod is in Pending state on a newly added node"
+        isCorrect: false
+  - id: "q4"
+    text: "What tool does kubectl diff compare to produce its output?"
+    type: "single-answer"
+    marks: 2
+    explanation: "kubectl diff compares the live state currently stored in the Kubernetes cluster against the incoming manifest to show which fields will change if the manifest is applied."
+    options:
+      - id: "a"
+        text: "The Git HEAD version of the file against the incoming manifest"
+        isCorrect: false
+      - id: "b"
+        text: "The live cluster state against the incoming manifest"
+        isCorrect: true
+      - id: "c"
+        text: "The Meshery design registry against the Kubernetes API server"
+        isCorrect: false
+      - id: "d"
+        text: "The previous Deployment revision against the new one"
+        isCorrect: false
+  - id: "q5"
+    text: "Why should kubectl rollout undo NOT be used as the sole rollback mechanism in a GitOps workflow?"
+    type: "single-answer"
+    marks: 2
+    explanation: "kubectl rollout undo restores the previous Kubernetes Deployment revision in the cluster but does not update the file in Git. This creates a divergence between the Git source of truth and the actual cluster state, which can cause confusion for future deployments and audit reviews."
+    options:
+      - id: "a"
+        text: "It is slower than a Git revert and re-apply"
+        isCorrect: false
+      - id: "b"
+        text: "It does not work on Deployments that use rolling update strategy"
+        isCorrect: false
+      - id: "c"
+        text: "It restores cluster state but does not update the Git source of truth, creating a gap"
+        isCorrect: true
+      - id: "d"
+        text: "It requires Meshery Operator to be running and will fail if MeshSync is down"
+        isCorrect: false
+  - id: "q6"
+    text: "What information should an agent record after a successful deployment to make future rollbacks deterministic?"
+    type: "multiple-answers"
+    marks: 3
+    explanation: "The Git commit hash identifies exactly what was deployed, the Meshery Design ID ties the deployment to the Meshery record, and the rollout status for each Deployment confirms what the cluster state was at deployment time. These three together allow a rollback to target the precise previous state without guessing."
+    options:
+      - id: "a"
+        text: "The Git commit hash of the deployed design file"
+        isCorrect: true
+      - id: "b"
+        text: "The Meshery Design ID returned after import"
+        isCorrect: true
+      - id: "c"
+        text: "The rollout status for each Deployment"
+        isCorrect: true
+      - id: "d"
+        text: "The names of all engineers who reviewed the dry-run diff"
+        isCorrect: false
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/banner.svg
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/banner.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 220" role="img" aria-label="TCS Labs Academy">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b1f2a"/>
+      <stop offset="1" stop-color="#123642"/>
+    </linearGradient>
+    <linearGradient id="teal" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#00d3a7"/>
+      <stop offset="1" stop-color="#00b39f"/>
+    </linearGradient>
+  </defs>
+  <rect width="640" height="220" rx="14" fill="url(#bg)"/>
+  <rect x="0" y="0" width="8" height="220" fill="url(#teal)"/>
+  <!-- hexagon mark -->
+  <g transform="translate(96 110)">
+    <polygon points="0,-46 40,-23 40,23 0,46 -40,23 -40,-23" fill="none" stroke="url(#teal)" stroke-width="6"/>
+    <polygon points="0,-22 19,-11 19,11 0,22 -19,11 -19,-11" fill="url(#teal)" opacity="0.9"/>
+  </g>
+  <text x="170" y="96" font-family="Helvetica, Arial, sans-serif" font-size="40" font-weight="700" fill="#ffffff">TCS Labs Academy</text>
+  <text x="172" y="132" font-family="Helvetica, Arial, sans-serif" font-size="20" fill="#9fe8da">AI-Native Cloud Infrastructure with Meshery</text>
+  <text x="172" y="170" font-family="Helvetica, Arial, sans-serif" font-size="15" fill="#7fb6c4">LLMs &amp; coding agents for cloud native operations</text>
+</svg>

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/designing-infrastructure-with-ai-and-kanvas/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/designing-infrastructure-with-ai-and-kanvas/_index.md
@@ -1,0 +1,14 @@
+---
+type: "course"
+id: "designing-infrastructure-with-ai-and-kanvas"
+title: "1. Designing Infrastructure with AI + Kanvas"
+description: "Learn how to translate plain-language infrastructure requirements into concrete cloud native designs using an LLM and Meshery's Kanvas visual designer. This course covers the full loop from intent specification through AI-assisted proposal to human review and validation."
+weight: 1
+tags: ["ai","kanvas"]
+categories: "AI"
+level: "intermediate"
+---
+
+Platform and infrastructure engineers increasingly work alongside coding agents and LLMs to turn high-level requirements into deployable cloud native topologies. This course establishes the foundational workflow: writing a clear infrastructure brief, letting an LLM propose a design, collaborating with that design in Kanvas, and critically reviewing the result before it reaches your cluster.
+
+You will learn what an LLM needs from you to produce a useful proposal, how the human-in-the-loop checkpoint inside Kanvas prevents silent errors from reaching production, and what a structured review checklist looks like for AI-generated infrastructure. Each lesson builds on the previous one, so by the end you can run the full intent-to-design cycle on your own projects.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/designing-infrastructure-with-ai-and-kanvas/from-intent-to-design/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/designing-infrastructure-with-ai-and-kanvas/from-intent-to-design/_index.md
@@ -1,0 +1,10 @@
+---
+type: "module"
+id: "from-intent-to-design"
+title: "From Intent to Design"
+description: "Walk the complete cycle from a plain-language requirement to a reviewed Kanvas design, using an LLM as your design collaborator."
+weight: 1
+tags: ["kanvas"]
+categories: "AI"
+level: "intermediate"
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/designing-infrastructure-with-ai-and-kanvas/from-intent-to-design/co-designing-in-kanvas/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/designing-infrastructure-with-ai-and-kanvas/from-intent-to-design/co-designing-in-kanvas/_index.md
@@ -1,0 +1,69 @@
+---
+type: "page"
+id: "co-designing-in-kanvas"
+title: "Co-Designing in Kanvas"
+description: "Understand the human+AI design loop in Kanvas, where an LLM proposes components and you arrange, validate, and approve them visually."
+weight: 2
+---
+
+## Kanvas as the Shared Canvas
+
+Kanvas is Meshery's visual infrastructure designer. It renders your infrastructure as a canvas of components - Deployments, Services, ConfigMaps, Ingresses, NetworkPolicies, and every other resource in the Meshery registry - that you can arrange, connect, annotate, and export as a Meshery design.
+
+When you work with an LLM on an infrastructure design task, Kanvas serves as the single shared artifact. The LLM outputs a set of component definitions; Kanvas makes those definitions visual and interactive. You inspect them, reposition them for clarity, add relationships the LLM missed, and remove or modify anything that does not match your requirements. Neither side of this loop is optional: the LLM brings breadth and speed, and you bring domain judgment and accountability.
+
+## The Agentic Loop in Practice
+
+A coding agent driving infrastructure design typically follows this sequence:
+
+1. **Receive the brief** - The agent reads your infrastructure brief (see lesson 3 for how to write one) and identifies the required components from the Meshery registry.
+2. **Propose a design** - The agent emits component definitions - YAML or Meshery design format - covering workloads, services, networking, and storage.
+3. **Load into Kanvas** - The design is imported into Meshery, either by the agent via the Meshery API or by you via `mesheryctl design import`.
+4. **Human checkpoint** - You open Kanvas, inspect the canvas, and either accept, modify, or reject the proposal.
+5. **Iterate** - If you reject or modify, you communicate the change back to the agent, which produces a revised proposal. The loop repeats until the design is approved.
+
+This loop is what "human-in-the-loop" means in practice: not a passive review at the end, but an active checkpoint after every agent proposal. Kanvas makes that checkpoint concrete because you can see the full topology - not just a list of YAML files - and spot missing connections, over-privileged pods, or absent NetworkPolicies at a glance.
+
+## What You Do in Each Iteration
+
+When you open a proposed design in Kanvas, your job is structured, not open-ended. Work through these actions in order:
+
+### 1. Check component presence
+
+Scan the canvas for components your brief required. Open the component panel on the left and verify that every workload, service, and storage resource you specified is present. Missing components are the most common LLM omission.
+
+### 2. Validate relationships
+
+Kanvas renders relationships between components - Service-to-Deployment selectors, Ingress-to-Service backends, PVC-to-StatefulSet bindings. A broken or missing relationship shows as a disconnected component or a warning in the relationship panel. Fix these before moving on.
+
+### 3. Arrange for readability
+
+Drag components into a layout that reflects your mental model of the system: frontend components at the top, data layer at the bottom, namespace boundaries visible. This is not cosmetic - a readable layout surfaces architectural problems that a flat list of YAML files hides.
+
+### 4. Annotate for your team
+
+Add annotations to components that need explanation - why a particular resource limit was chosen, which team owns a service, which NetworkPolicy applies to which namespace. Annotations persist in the design and travel with it into the Meshery Catalog if you publish there.
+
+### 5. Export or approve
+
+When the design passes your review, export it as a Kubernetes manifest or save it as a Meshery design for reuse. The `designs/observability-stack.yaml` in the academy repository is an example of a Kanvas-exported design you can study and import:
+
+```bash
+mesheryctl design import -f designs/observability-stack.yaml -s "Kubernetes Manifest"
+```
+
+## The Human-in-the-Loop Checkpoint
+
+The Kanvas checkpoint is not a formality. It is the moment when infrastructure intent (your brief), LLM capability (the proposal), and operational reality (your cluster's constraints) are reconciled. An LLM cannot know your organization's NetworkPolicy conventions, your team's naming standards, or the resource quotas on your namespace. You do. The checkpoint is where that knowledge enters the design.
+
+Skipping or rushing the checkpoint is where AI-assisted infrastructure work fails. A design that looks complete in YAML can have subtle problems - a selector mismatch, a missing resource limit, a port collision - that are visible in Kanvas's relationship view but invisible in a text diff. Use the visual layer for what it is good at.
+
+## Persisting the Loop with Meshery
+
+Meshery's design system persists each iteration. Every version of a design you save is stored, and you can return to an earlier version if an iteration makes things worse. Use environments and workspaces to organize designs by team or cluster target, so the co-design loop for one project does not pollute another.
+
+When the loop is complete and the design is approved, Meshery's MeshSync will reconcile the design's intended state with your cluster's actual state, and Meshery Operator will maintain that reconciliation over time.
+
+## Summary
+
+Co-designing in Kanvas means running a structured iteration loop: the LLM proposes, you inspect visually, you correct and iterate. The human checkpoint after each proposal is where domain judgment overrides LLM assumption. Kanvas makes that checkpoint fast and concrete by rendering the full topology rather than a wall of YAML.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/designing-infrastructure-with-ai-and-kanvas/from-intent-to-design/describing-infrastructure-in-natural-language/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/designing-infrastructure-with-ai-and-kanvas/from-intent-to-design/describing-infrastructure-in-natural-language/_index.md
@@ -1,0 +1,123 @@
+---
+type: "page"
+id: "describing-infrastructure-in-natural-language"
+title: "Describing Infrastructure in Natural Language"
+description: "Write an infrastructure brief that gives an LLM the functional needs, constraints, and non-functionals required to produce a reviewable design proposal."
+weight: 3
+---
+
+## Why the Brief Is the Critical Artifact
+
+The infrastructure brief is the document you hand to an LLM before asking it to design anything. It is not a vague starting point you refine later - it is the primary determinant of output quality. A weak brief produces a plausible-looking but incorrect design. A strong brief produces a reviewable proposal with a short correction list.
+
+Writing a good brief is an engineering skill, not a writing skill. It requires the same thinking as writing a technical spec: define the system boundary, state the functional requirements, constrain the non-functionals, and explicitly exclude what is out of scope.
+
+## Structure of an Infrastructure Brief
+
+A brief that produces reliable LLM output has four sections. Each section answers a specific question that the LLM cannot answer from context alone.
+
+### Section 1: Functional Requirements
+
+What does this infrastructure need to do? Name every service, its role, and its external dependencies.
+
+```text
+## Functional Requirements
+
+- API server: receives HTTP requests from external clients, routes to downstream services
+- Worker: consumes jobs from a queue, writes results to the database, no direct client traffic
+- Queue: message broker (one topic, "jobs"), written to by API server, read by worker
+- Database: relational, written and read by worker only
+- Cache: key-value, read by API server to reduce downstream calls
+```
+
+Write one line per component. The LLM reads this as a component list. If you do not name it here, the LLM will not include it.
+
+### Section 2: Constraints
+
+What must be true about how these components are deployed? Constraints bound the design space.
+
+```text
+## Constraints
+
+- All components in a single namespace: "payments"
+- No component may be exposed outside the cluster except the API server (Ingress on port 443)
+- Services must not share a database instance
+- Worker must not be reachable from outside the namespace
+- TLS termination at Ingress only; internal traffic plain HTTP/2
+```
+
+Constraints are the most valuable part of the brief because they prevent the LLM from generating correct-looking but policy-violating designs. Write them as negative requirements ("must not") as well as positive ones ("must").
+
+### Section 3: Non-Functional Requirements
+
+Scale, availability, security posture, observability, and resource limits. These are the properties that distinguish a production design from a prototype.
+
+```text
+## Non-Functional Requirements
+
+Scale:
+  - API server: 2-10 replicas (HPA on CPU 60%)
+  - Worker: 1-3 replicas (HPA on queue depth)
+  - Database: 1 replica (StatefulSet), no scaling
+
+Availability:
+  - API server: PodDisruptionBudget, minAvailable: 1
+  - Worker: no PDB required
+
+Security:
+  - Pod security standard: restricted on all pods
+  - No privileged containers or hostPath mounts
+  - Non-root user for all containers
+  - Read-only root filesystem where possible
+
+Observability:
+  - Prometheus scrape annotations on all Deployments
+  - Structured JSON logging to stdout
+  - No sidecar injection required at this stage
+
+Resource limits:
+  - Set CPU request/limit and memory request/limit on all containers
+  - Suggest reasonable defaults based on service role
+```
+
+An LLM that receives this section will produce a design with HPAs, PDBs, security contexts, and resource requests. An LLM that does not receive this section will omit most of them.
+
+### Section 4: Exclusions
+
+What is explicitly out of scope? This prevents the LLM from making decisions you have not authorized.
+
+```text
+## Exclusions
+
+- No service mesh (Istio, Linkerd) at this stage
+- No cert-manager or externally managed TLS certificates
+- No persistent volume snapshots or backup configuration
+- No CI/CD pipeline resources (no Tekton, no Argo Workflows)
+```
+
+Exclusions are cheap to write and expensive to omit. Without them, the LLM may add a service mesh because your brief mentions "TLS" and the model associates the two. An explicit exclusion removes that ambiguity.
+
+## What to Leave Out
+
+The brief is not a design. Do not specify:
+
+- Container image tags or registries (the LLM can use a placeholder; you will update before deployment)
+- Exact label selectors (the LLM should follow convention; you will review in Kanvas)
+- Boilerplate annotations (let the LLM fill these from its training)
+- The implementation language or framework of any service (irrelevant to the infrastructure topology)
+
+These details belong in your review checklist (lesson 4), not in the brief.
+
+## Practical Example
+
+The academy's `designs/llm-mcp-gateway.yaml` represents a complete design produced from a brief that specified: a gateway service exposing an MCP endpoint, a model-routing backend, and an internal policy enforcement layer. You can import it and read the resulting topology in Kanvas to see how a well-specified brief translates to a concrete design:
+
+```bash
+mesheryctl design import -f designs/llm-mcp-gateway.yaml -s "Kubernetes Manifest"
+```
+
+Compare what you see in Kanvas to the four brief sections above. Every component, constraint, and non-functional requirement in the brief should have a corresponding artifact in the design.
+
+## Summary
+
+A useful infrastructure brief has four sections: functional requirements (what to build), constraints (what must be true), non-functionals (scale, security, observability), and exclusions (what to omit). Writing it is the engineering work that determines the quality of everything the LLM produces. The brief is not a first draft - it is the specification. Treat it with that rigor.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/designing-infrastructure-with-ai-and-kanvas/from-intent-to-design/from-intent-to-topology/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/designing-infrastructure-with-ai-and-kanvas/from-intent-to-design/from-intent-to-topology/_index.md
@@ -1,0 +1,90 @@
+---
+type: "page"
+id: "from-intent-to-topology"
+title: "From Intent to Topology"
+description: "Translate a plain-language infrastructure requirement into a concrete cloud native topology covering workloads, services, data, and networking."
+weight: 1
+---
+
+## What is a Topology?
+
+A cloud native topology is the explicit, structured representation of everything that needs to exist in your cluster - or across clusters - to satisfy a requirement. It names each workload (Deployments, StatefulSets, Jobs), the Services that expose them, the data stores they depend on, the networking rules that connect or isolate them, and the relationships between all of those components.
+
+When you start with a plain-language requirement - "run a checkout service that persists orders to a database and exposes an API to the frontend" - you have an intent, not a topology. The gap between intent and topology is where most design errors live. Closing that gap deliberately, rather than by intuition, is what this lesson is about.
+
+## What an LLM Needs to Produce a Useful Design
+
+An LLM working on infrastructure design is solving a constraint-satisfaction problem. The more constraints you supply, the fewer gaps it has to fill with assumptions, and the fewer corrections you need to make afterward.
+
+At minimum, give an LLM the following four categories of information:
+
+| Category | What to specify | Example |
+|---|---|---|
+| **Workloads** | Services and their roles | "A stateless API server, a background worker, and a cache" |
+| **Data** | Persistence and access patterns | "PostgreSQL for orders; Redis for session state; no cross-service DB sharing" |
+| **Networking** | Exposure and isolation | "API server exposed via Ingress; worker and DB internal only; TLS required" |
+| **Non-functionals** | Scale, availability, security | "API server scales from 2-10 replicas; worker is single-instance; pod security standards: restricted" |
+
+If any of these four are absent, the LLM will make a choice. Sometimes it will make the right one. You cannot count on that in production.
+
+## Walking Through an Example
+
+Suppose your requirement is:
+
+> "Deploy a microservices demo with a frontend, a cart service, a product catalog, and a checkout service. The checkout service writes to a database. Everything should be observable."
+
+That sentence contains: workload names (frontend, cart, catalog, checkout), a data dependency (checkout writes to DB), and a non-functional intent (observable). It does not contain: replica counts, which database engine, how services communicate (HTTP, gRPC), whether there is an Ingress, what "observable" means in concrete terms (metrics? traces? logs?).
+
+Before passing this to an LLM, fill the gaps:
+
+```text
+Workloads:
+  - frontend: stateless, 2 replicas, Ingress on port 80/443
+  - cart: stateless, 2 replicas, internal ClusterIP
+  - catalog: stateless, 2 replicas, internal ClusterIP
+  - checkout: stateless, 2 replicas, internal ClusterIP
+
+Data:
+  - PostgreSQL (StatefulSet, 1 replica) for checkout only
+  - No direct DB access from frontend, cart, or catalog
+
+Networking:
+  - All inter-service communication over HTTP/2 (gRPC)
+  - frontend exposed via Ingress; all others ClusterIP only
+
+Non-functionals:
+  - Pod security standard: baseline
+  - Resource requests/limits required on all containers
+  - Prometheus scrape annotations on all Deployments
+  - No privileged containers
+```
+
+This brief is the input to the next lesson. The academy's `designs/microservices-demo.yaml` is an importable reference for this exact topology - you can load it with:
+
+```bash
+mesheryctl design import -f designs/microservices-demo.yaml -s "Kubernetes Manifest"
+```
+
+## Identifying the Topology Primitives
+
+Once you have a complete brief, map it to Kubernetes and Meshery primitives before the LLM does. This gives you a checklist to verify the output against:
+
+- **Workloads** - Deployment, StatefulSet, DaemonSet, or Job per service
+- **Services** - ClusterIP, NodePort, or LoadBalancer; one per workload minimum
+- **ConfigMaps and Secrets** - per environment variable surface
+- **Ingress or Gateway API** - one per external entry point
+- **NetworkPolicy** - one per namespace or isolation boundary
+- **PersistentVolumeClaim** - one per stateful workload
+- **ServiceAccount** - one per workload that calls the Kubernetes API or needs IRSA/Workload Identity
+
+If the topology you receive back from the LLM is missing any of these that your brief implied, that is a gap to fix before the design reaches your cluster.
+
+## What to Leave Unspecified
+
+Not everything needs to be in the brief. Container image tags, exact label selectors, and annotation formats are details the LLM can fill in from convention - and that you will review visually in Kanvas. Over-specifying at this stage creates noise that can distract the LLM from the structural decisions that actually matter.
+
+Leave out: specific image versions, exact CPU/memory values (specify "set reasonable defaults"), and boilerplate labels. Your review step - covered in lesson 4 - is the right place to inspect and correct those.
+
+## Summary
+
+The jump from intent to topology requires you to specify workloads, data, networking, and non-functionals before asking an LLM to design anything. Gaps you leave become assumptions the LLM makes. Make the gaps intentional and small, and your AI-assisted design session will produce something reviewable rather than something that needs to be rebuilt from scratch.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/designing-infrastructure-with-ai-and-kanvas/from-intent-to-design/quiz.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/designing-infrastructure-with-ai-and-kanvas/from-intent-to-design/quiz.md
@@ -1,0 +1,76 @@
+---
+title: "Module Quiz"
+passPercentage: 70
+type: "test"
+questions:
+  - id: "q1"
+    text: "Which four categories of information should you always provide in an infrastructure brief before asking an LLM to design a topology?"
+    type: "multiple-answers"
+    marks: 2
+    explanation: "A brief needs workloads, data, networking, and non-functionals. Without all four, the LLM fills gaps with assumptions that often do not match production requirements."
+    options:
+      - id: "a"
+        text: "Workloads and their roles"
+        isCorrect: true
+      - id: "b"
+        text: "Container image tags and registries"
+        isCorrect: false
+      - id: "c"
+        text: "Data and persistence requirements"
+        isCorrect: true
+      - id: "d"
+        text: "Networking exposure and isolation rules"
+        isCorrect: true
+      - id: "e"
+        text: "Non-functional requirements (scale, security, observability)"
+        isCorrect: true
+
+  - id: "q2"
+    text: "In the human+AI co-design loop, what is the primary purpose of the Kanvas visual checkpoint?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Kanvas renders the full topology visually, making missing components, broken relationships, and structural problems visible in a way that a text diff of YAML files does not."
+    options:
+      - id: "a"
+        text: "To automatically apply the design to the cluster without further review"
+        isCorrect: false
+      - id: "b"
+        text: "To render the full topology so a human can inspect, correct, and approve before the design proceeds"
+        isCorrect: true
+      - id: "c"
+        text: "To replace the infrastructure brief with a visual equivalent"
+        isCorrect: false
+      - id: "d"
+        text: "To generate YAML from a diagram drawn by the user"
+        isCorrect: false
+
+  - id: "q3"
+    text: "What command imports an existing design file into Meshery using the Kubernetes Manifest source?"
+    type: "short-answer"
+    marks: 2
+    correctAnswer: "mesheryctl design import -f <file> -s \"Kubernetes Manifest\""
+    case_sensitive: false
+    explanation: "The mesheryctl design import command with the -f flag for the file path and -s flag for the source type is the correct way to load a design into Meshery."
+
+  - id: "q4"
+    text: "When reviewing an AI-proposed design, which of the following are security red flags you should check explicitly?"
+    type: "multiple-answers"
+    marks: 2
+    explanation: "Security review must check for root containers, privileged settings, hostPath mounts, and hardcoded secrets. These are the most common permissive defaults in AI-generated designs."
+    options:
+      - id: "a"
+        text: "Containers running as root or with allowPrivilegeEscalation"
+        isCorrect: true
+      - id: "b"
+        text: "HPA min and max replica counts"
+        isCorrect: false
+      - id: "c"
+        text: "Container images using the latest tag"
+        isCorrect: true
+      - id: "d"
+        text: "Secrets hardcoded in ConfigMaps rather than referenced from Secret objects"
+        isCorrect: true
+      - id: "e"
+        text: "Service selector label values"
+        isCorrect: false
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/designing-infrastructure-with-ai-and-kanvas/from-intent-to-design/reviewing-an-ai-proposed-design/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/designing-infrastructure-with-ai-and-kanvas/from-intent-to-design/reviewing-an-ai-proposed-design/_index.md
@@ -1,0 +1,98 @@
+---
+type: "page"
+id: "reviewing-an-ai-proposed-design"
+title: "Reviewing an AI-Proposed Design"
+description: "Apply a structured review checklist to an AI-generated infrastructure design, catching completeness gaps, correctness issues, and security and resource red flags."
+weight: 4
+---
+
+## Why Review Is Not Optional
+
+An LLM generates plausible infrastructure. It does not generate correct infrastructure. The distinction matters because a plausible-but-incorrect design will pass a casual read and fail under load, under attack, or during a maintenance window. Your review is the control that closes that gap.
+
+Reviewing an AI-proposed design is not about reading YAML carefully. It is a structured process with four dimensions: completeness, correctness, security, and resource hygiene. Each dimension has a short checklist. Working through all four takes less time than debugging a production incident that a missed item would have caused.
+
+## The Four Review Dimensions
+
+### 1. Completeness
+
+Does the design contain everything the brief required? Compare the brief (lesson 3) to the canvas in Kanvas component by component.
+
+**Completeness checklist:**
+
+- [ ] Every workload named in the brief has a corresponding Deployment, StatefulSet, or Job
+- [ ] Every workload has a corresponding Service (ClusterIP minimum)
+- [ ] Every external entry point has an Ingress or Gateway resource
+- [ ] Every stateful workload has a PersistentVolumeClaim
+- [ ] Every workload that the brief specified as autoscaled has an HorizontalPodAutoscaler
+- [ ] Every workload listed in the brief's exclusions is absent from the design
+
+Missing components are the most common LLM error. Run through this list before moving to the other dimensions.
+
+### 2. Correctness
+
+Do the components that are present actually do what they are supposed to do? This is where selector mismatches, wrong port references, and broken relationships hide.
+
+**Correctness checklist:**
+
+- [ ] Service selectors match the labels on their target Deployment pods
+- [ ] Ingress backend service names and port numbers match the corresponding Service definitions
+- [ ] HPA target references match the correct Deployment name
+- [ ] PVC storageClassName is appropriate for the cluster (or omitted to use the default)
+- [ ] Container port numbers in Deployment specs match the ports in the corresponding Service
+
+In Kanvas, a broken relationship - for example, a Service that does not resolve to a Deployment - is visible as a disconnected or warning-state edge between components. Use the relationship view to catch these before they reach `kubectl apply`.
+
+### 3. Security Red Flags
+
+AI-generated designs frequently default to permissive security settings because they optimize for "works" rather than "works securely." Check each of the following explicitly.
+
+**Security checklist:**
+
+- [ ] No container runs as root (check `securityContext.runAsNonRoot: true`)
+- [ ] No container has `privileged: true` or `allowPrivilegeEscalation: true`
+- [ ] No container mounts `hostPath` volumes
+- [ ] Pod security standard is set at the namespace level (label `pod-security.kubernetes.io/enforce`)
+- [ ] NetworkPolicy resources are present and restrict ingress/egress to the minimum required
+- [ ] Secrets are referenced as environment variables from Secret objects, not hardcoded in ConfigMaps
+- [ ] No container image uses the `latest` tag (demand a pinned tag or a placeholder that forces an explicit update)
+
+If the brief specified `pod security standard: restricted`, every container in the design must satisfy the restricted profile. Check this mechanically - do not assume the LLM applied it consistently.
+
+### 4. Resource Hygiene
+
+Under-specified resources cause cluster instability. Over-specified resources waste capacity. Both are design errors.
+
+**Resource hygiene checklist:**
+
+- [ ] Every container has `resources.requests.cpu` and `resources.requests.memory` set
+- [ ] Every container has `resources.limits.memory` set (CPU limit is optional but memory limit is required to prevent OOM kill cascades)
+- [ ] HPA min and max replica counts are consistent with the brief's availability requirements
+- [ ] PodDisruptionBudgets are present for workloads the brief marked as availability-sensitive
+- [ ] No container has a memory limit lower than its memory request
+
+A design from `designs/policy-guardrails.yaml` demonstrates resource hygiene applied across a multi-service topology. Import it and compare its resource specifications to this checklist:
+
+```bash
+mesheryctl design import -f designs/policy-guardrails.yaml -s "Kubernetes Manifest"
+```
+
+## A Short Review Workflow
+
+Apply the four dimensions in order on the Kanvas canvas:
+
+1. **Open the design in Kanvas.** Use the visual layout to get a spatial overview before reading any YAML.
+2. **Run the completeness check.** Mark off each expected component. Note any missing ones.
+3. **Inspect relationships.** Switch to the relationship view and verify selector correctness and port references.
+4. **Read security contexts.** Open each component's detail panel and check the security context fields.
+5. **Read resource specs.** Verify requests, limits, and HPA parameters for every workload.
+6. **Compile a correction list.** Write down every item that failed a check. Do not fix items in the canvas directly - return the list to the LLM as a correction brief and let it generate a revised proposal.
+7. **Re-review the revision.** Run the same four dimensions on the revised design. The revision loop is expected - do not skip it because the first pass looked mostly correct.
+
+## When to Escalate
+
+Some findings during review are not corrections to send back to the LLM - they are signals that the brief was incomplete. If you find yourself inventing requirements during review ("we should probably add a NetworkPolicy for this"), stop and update the brief. Then regenerate from the revised brief rather than patching the design manually. A patched design diverges from its source-of-truth brief, which creates a maintenance problem later.
+
+## Summary
+
+Review an AI-proposed design across four dimensions: completeness (is everything present?), correctness (do selectors and ports resolve?), security (no root containers, no permissive profiles, NetworkPolicies in place), and resource hygiene (requests, limits, HPA bounds all set). Work through the dimensions in order, compile a correction list, and return it to the LLM for a revised proposal. Repeat until the design passes all four dimensions.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/designing-infrastructure-with-ai-and-kanvas/test.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/designing-infrastructure-with-ai-and-kanvas/test.md
@@ -1,0 +1,125 @@
+---
+title: "Course Test"
+passPercentage: 70
+type: "test"
+questions:
+  - id: "q1"
+    text: "What is the gap between an infrastructure 'intent' and a 'topology'?"
+    type: "single-answer"
+    marks: 2
+    explanation: "An intent is a plain-language requirement. A topology is the explicit, structured representation of every workload, service, data store, and networking rule needed to satisfy that requirement. The gap is where most design errors occur."
+    options:
+      - id: "a"
+        text: "The intent is written in YAML; the topology is written in natural language"
+        isCorrect: false
+      - id: "b"
+        text: "The intent states what is needed; the topology names every component, service, data dependency, and networking rule required to deliver it"
+        isCorrect: true
+      - id: "c"
+        text: "The intent is created by the LLM; the topology is created by the engineer"
+        isCorrect: false
+      - id: "d"
+        text: "There is no gap - a well-written intent is equivalent to a topology"
+        isCorrect: false
+
+  - id: "q2"
+    text: "Which Kubernetes primitives should you map out before handing a brief to an LLM, to use as a completeness checklist for the output?"
+    type: "multiple-answers"
+    marks: 2
+    explanation: "Before asking the LLM to design, you should identify the expected Deployments or StatefulSets, Services, Ingress or Gateway resources, NetworkPolicies, PersistentVolumeClaims, ConfigMaps, Secrets, and ServiceAccounts. These form the checklist you verify against the proposal."
+    options:
+      - id: "a"
+        text: "Deployment or StatefulSet per workload"
+        isCorrect: true
+      - id: "b"
+        text: "Service per workload"
+        isCorrect: true
+      - id: "c"
+        text: "Helm chart version per dependency"
+        isCorrect: false
+      - id: "d"
+        text: "NetworkPolicy per namespace or isolation boundary"
+        isCorrect: true
+      - id: "e"
+        text: "PersistentVolumeClaim per stateful workload"
+        isCorrect: true
+
+  - id: "q3"
+    text: "In the co-design loop, what should you do when you find a problem in the Kanvas canvas after an LLM proposal?"
+    type: "single-answer"
+    marks: 2
+    explanation: "The correct action is to compile a correction list and return it to the LLM as a correction brief for a revised proposal. Fixing items directly on the canvas causes the design to diverge from its source-of-truth brief."
+    options:
+      - id: "a"
+        text: "Fix the problem directly in the Kanvas canvas and deploy"
+        isCorrect: false
+      - id: "b"
+        text: "Discard the design and start over without LLM assistance"
+        isCorrect: false
+      - id: "c"
+        text: "Compile a correction list and return it to the LLM as a correction brief, then review the revised proposal"
+        isCorrect: true
+      - id: "d"
+        text: "Skip the problem if it appears minor and proceed to deployment"
+        isCorrect: false
+
+  - id: "q4"
+    text: "What does an 'Exclusions' section in an infrastructure brief accomplish?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Exclusions explicitly tell the LLM what is out of scope - preventing it from adding components you have not authorized, such as a service mesh when TLS is mentioned. Without exclusions, the LLM may make associations from training data that violate your requirements."
+    options:
+      - id: "a"
+        text: "Lists the components the LLM must include in the design"
+        isCorrect: false
+      - id: "b"
+        text: "Prevents the LLM from adding unauthorized components by explicitly stating what is out of scope"
+        isCorrect: true
+      - id: "c"
+        text: "Documents components that were considered but are deferred to a future iteration"
+        isCorrect: false
+      - id: "d"
+        text: "Reduces the context window size by removing irrelevant information"
+        isCorrect: false
+
+  - id: "q5"
+    text: "Which of the following are resource hygiene checks you should perform when reviewing an AI-proposed design?"
+    type: "multiple-answers"
+    marks: 2
+    explanation: "Resource hygiene requires that every container has CPU and memory requests set, memory limits set, HPA bounds match availability requirements, and PodDisruptionBudgets are in place for availability-sensitive workloads. Missing any of these can cause cluster instability or wasted capacity."
+    options:
+      - id: "a"
+        text: "Every container has resources.requests.cpu and resources.requests.memory set"
+        isCorrect: true
+      - id: "b"
+        text: "Every container has resources.limits.memory set"
+        isCorrect: true
+      - id: "c"
+        text: "Every Service uses the LoadBalancer type for external access"
+        isCorrect: false
+      - id: "d"
+        text: "PodDisruptionBudgets are present for availability-sensitive workloads"
+        isCorrect: true
+      - id: "e"
+        text: "HPA min and max replica counts are consistent with brief availability requirements"
+        isCorrect: true
+
+  - id: "q6"
+    text: "When during a design review should you update the infrastructure brief rather than sending a correction list to the LLM?"
+    type: "single-answer"
+    marks: 2
+    explanation: "If you find yourself inventing requirements during review - recognizing a need that was never stated in the brief - that is a signal the brief was incomplete. Stop, update the brief, and regenerate. Patching the design manually creates divergence from the source-of-truth brief."
+    options:
+      - id: "a"
+        text: "When the design has more than three corrections needed"
+        isCorrect: false
+      - id: "b"
+        text: "When you discover during review that you are inventing requirements that were never in the brief"
+        isCorrect: true
+      - id: "c"
+        text: "When the LLM proposal is more than 100 lines of YAML"
+        isCorrect: false
+      - id: "d"
+        text: "When the design passes the completeness check but fails the security check"
+        isCorrect: false
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/exam.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/exam.md
@@ -1,0 +1,176 @@
+---
+title: "Learning Path Exam"
+passPercentage: 70
+timeLimit: 35
+type: "test"
+questions:
+  - id: "q1"
+    text: "When turning intent into a topology, what should a good infrastructure brief to an LLM include? (Select all that apply.)"
+    type: "multiple-answers"
+    marks: 3
+    explanation: "Functional needs, constraints, and non-functional requirements (scale, security) all shape a correct design. The model's internal weights are not something you specify."
+    options:
+      - id: "a"
+        text: "Functional requirements (what it must do)"
+        isCorrect: true
+      - id: "b"
+        text: "Constraints (namespaces, images, limits)"
+        isCorrect: true
+      - id: "c"
+        text: "Non-functional requirements (scale, security)"
+        isCorrect: true
+      - id: "d"
+        text: "The model's training weights"
+        isCorrect: false
+  - id: "q2"
+    text: "What role does Kanvas play when co-designing with an AI?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Kanvas is the shared visual canvas and a human-in-the-loop checkpoint: the AI proposes components, you arrange and validate them before deploying."
+    options:
+      - id: "a"
+        text: "It trains the LLM on your cluster"
+        isCorrect: false
+      - id: "b"
+        text: "It is the shared canvas and human-in-the-loop checkpoint for proposed designs"
+        isCorrect: true
+      - id: "c"
+        text: "It replaces the need to review designs"
+        isCorrect: false
+      - id: "d"
+        text: "It is a load generator"
+        isCorrect: false
+  - id: "q3"
+    text: "A Meshery design (Kubernetes Manifest source) is fundamentally what?"
+    type: "single-answer"
+    marks: 2
+    explanation: "It is valid Kubernetes YAML (often multi-document) that Meshery can import, visualize, validate, and deploy."
+    options:
+      - id: "a"
+        text: "A proprietary binary format"
+        isCorrect: false
+      - id: "b"
+        text: "Valid Kubernetes YAML that Meshery can import and deploy"
+        isCorrect: true
+      - id: "c"
+        text: "A Grafana dashboard"
+        isCorrect: false
+      - id: "d"
+        text: "A container image manifest"
+        isCorrect: false
+  - id: "q4"
+    text: "Which prompt instruction most improves the chance of importable design YAML?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Telling the model to output only valid YAML (no commentary) and to use specific, current resource kinds yields a clean, importable artifact."
+    options:
+      - id: "a"
+        text: "'Be as verbose as possible'"
+        isCorrect: false
+      - id: "b"
+        text: "'Output only valid YAML using these resource kinds; no commentary'"
+        isCorrect: true
+      - id: "c"
+        text: "'Invent any apiVersion you like'"
+        isCorrect: false
+      - id: "d"
+        text: "'Skip resource limits'"
+        isCorrect: false
+  - id: "q5"
+    text: "Which are common mistakes in LLM-generated Kubernetes designs? (Select all that apply.)"
+    type: "multiple-answers"
+    marks: 3
+    explanation: "Outdated apiVersions, selector/label mismatches, and missing resource limits are all common; using a Namespace is correct practice, not a mistake."
+    options:
+      - id: "a"
+        text: "Deprecated or wrong apiVersion"
+        isCorrect: true
+      - id: "b"
+        text: "Service selector not matching pod labels"
+        isCorrect: true
+      - id: "c"
+        text: "Missing resource requests/limits"
+        isCorrect: true
+      - id: "d"
+        text: "Placing resources in a Namespace"
+        isCorrect: false
+  - id: "q6"
+    text: "In the agent deploy loop, what should happen before any change is applied to a cluster?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Preview the change with a dry-run/diff and have a human approve it - bounding blast radius before applying."
+    options:
+      - id: "a"
+        text: "Apply first, review later"
+        isCorrect: false
+      - id: "b"
+        text: "Preview with a dry-run/diff and get human approval"
+        isCorrect: true
+      - id: "c"
+        text: "Delete the namespace"
+        isCorrect: false
+      - id: "d"
+        text: "Disable validation"
+        isCorrect: false
+  - id: "q7"
+    text: "What is the correct way to roll back a bad design change that is tracked in Git?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Revert the change in Git and re-deploy the previous known-good design (optionally using kubectl rollout undo as an immediate stopgap)."
+    options:
+      - id: "a"
+        text: "Edit production by hand and hope it sticks"
+        isCorrect: false
+      - id: "b"
+        text: "git revert the change and re-deploy the previous known-good design"
+        isCorrect: true
+      - id: "c"
+        text: "Delete the Git history"
+        isCorrect: false
+      - id: "d"
+        text: "Turn off MeshSync"
+        isCorrect: false
+  - id: "q8"
+    text: "What kind of error does Meshery's relationship validation catch that plain schema validation does not?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Relationship validation catches semantic errors - how components must relate - not just whether each object's fields are individually well-formed."
+    options:
+      - id: "a"
+        text: "Spelling errors in comments"
+        isCorrect: false
+      - id: "b"
+        text: "Semantic errors in how components relate to each other"
+        isCorrect: true
+      - id: "c"
+        text: "Slow container image pulls"
+        isCorrect: false
+      - id: "d"
+        text: "Git merge conflicts"
+        isCorrect: false
+  - id: "q9"
+    text: "Which Kubernetes objects make good standing guardrails for AI-generated workloads?"
+    type: "multiple-answers"
+    marks: 3
+    explanation: "ResourceQuota, LimitRange, and NetworkPolicy all bound what generated infra can do. A ConfigMap stores configuration; it is not a guardrail."
+    options:
+      - id: "a"
+        text: "ResourceQuota"
+        isCorrect: true
+      - id: "b"
+        text: "LimitRange"
+        isCorrect: true
+      - id: "c"
+        text: "NetworkPolicy"
+        isCorrect: true
+      - id: "d"
+        text: "ConfigMap"
+        isCorrect: false
+  - id: "q10"
+    text: "Before merging AI-generated infrastructure, your review checklist should confirm correctness, security, resources, policy, and what else?"
+    type: "short-answer"
+    marks: 2
+    correctAnswer: "rollback"
+    case_sensitive: false
+    explanation: "Rollback readiness (can you safely revert?) is the fifth pillar of a sound review checklist for AI-generated infrastructure."
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/generating-meshery-designs-with-llms/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/generating-meshery-designs-with-llms/_index.md
@@ -1,0 +1,14 @@
+---
+type: "course"
+id: "generating-meshery-designs-with-llms"
+title: "2. Generating Meshery Designs with LLMs"
+description: "Learn to generate valid, importable Meshery designs with an LLM: understand the YAML structure, craft precise prompts, align output with the Meshery registry, and iteratively refine designs in Kanvas."
+weight: 2
+tags: ["ai","designs"]
+categories: "AI"
+level: "intermediate"
+---
+
+Meshery designs are valid Kubernetes YAML - multi-document files that Meshery imports, visualises, and deploys. Getting an LLM to produce designs that pass import and validation requires more than asking it to "write some YAML". You need to understand the structure a design must have, give the model the right constraints and context, verify that generated resources align with Meshery's component registry, and refine iteratively rather than starting from scratch on every failure.
+
+This course walks through all four stages of that workflow. You will start by dissecting the anatomy of a real importable design, move through prompting and constraint techniques, learn why registry alignment matters and how validation surfaces mismatches, and finish with a disciplined iteration loop that converges on a correct, deployable design. The designs used throughout - including `designs/microservices-demo.yaml` - are importable directly with `mesheryctl design import -f <file> -s "Kubernetes Manifest"`.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/generating-meshery-designs-with-llms/generating-designs/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/generating-meshery-designs-with-llms/generating-designs/_index.md
@@ -1,0 +1,10 @@
+---
+type: "module"
+id: "generating-designs"
+title: "Generating Designs"
+description: "Produce valid, importable Meshery designs using an LLM, from understanding YAML structure through registry alignment and iterative refinement."
+weight: 1
+tags: ["designs"]
+categories: "AI"
+level: "intermediate"
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/generating-meshery-designs-with-llms/generating-designs/anatomy-of-a-meshery-design/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/generating-meshery-designs-with-llms/generating-designs/anatomy-of-a-meshery-design/_index.md
@@ -1,0 +1,134 @@
+---
+type: "page"
+id: "anatomy-of-a-meshery-design"
+title: "Anatomy of a Meshery Design"
+description: "Understand the structure of a Meshery design as valid Kubernetes YAML and what makes it importable."
+weight: 1
+---
+
+A Meshery design is nothing more than valid Kubernetes YAML - but the specifics of that YAML determine whether Meshery can import it, render it in Kanvas, and deploy it to a cluster. Before you ask an LLM to generate a design, you need to know exactly what a correct design looks like from the inside.
+
+## The Multi-Document Structure
+
+Kubernetes YAML supports multi-document files: multiple resource definitions in a single file, each separated by a `---` delimiter. Meshery imports these files as a single named design, parses each document, and maps each resource to a component in its registry.
+
+A minimal but realistic design contains at least:
+
+- A `Namespace` to scope all other resources
+- One or more `Deployment` resources
+- Corresponding `Service` resources
+
+The `designs/microservices-demo.yaml` file included in this academy is a three-tier example (frontend, API, cache) that follows this pattern exactly. Import it with:
+
+```bash
+mesheryctl design import -f designs/microservices-demo.yaml -s "Kubernetes Manifest"
+```
+
+The `-s "Kubernetes Manifest"` flag tells Meshery which design source type to use. If you omit it or pass a wrong value, the import fails before any YAML parsing occurs.
+
+## Document Order and the Namespace
+
+Always place the `Namespace` document first. Kubernetes itself does not enforce document ordering when you `kubectl apply`, but Meshery's import parser uses ordering to resolve intra-design references. Resources that reference a namespace that has not yet been parsed may fail validation.
+
+```yaml
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tcslabs-demo
+  labels:
+    app.kubernetes.io/part-of: tcslabs-academy
+```
+
+## Deployments and Label Selectors
+
+Every `Deployment` must have a `selector.matchLabels` block that matches the `template.metadata.labels` on the pod template. This is a Kubernetes requirement, not a Meshery one - but it is one of the most common points where LLM-generated YAML is wrong.
+
+```yaml
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: tcslabs-demo
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: api          # must match pod template labels
+  template:
+    metadata:
+      labels:
+        app: api        # must match selector above
+    spec:
+      containers:
+        - name: api
+          image: ghcr.io/stefanprodan/podinfo:6.6.2
+          ports:
+            - containerPort: 9898
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "200m"
+              memory: "128Mi"
+```
+
+Note the `resources` block. Meshery's validation will flag deployments that lack resource requests and limits - and a cluster with a `LimitRange` will reject them outright. Always include them.
+
+## Services and Port Mapping
+
+A `Service` must reference pod labels through its `selector`, and the `port`/`targetPort` values must align with the ports declared in the container spec.
+
+```yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  namespace: tcslabs-demo
+spec:
+  selector:
+    app: api
+  ports:
+    - port: 9898
+      targetPort: 9898
+```
+
+A common LLM mistake is setting `targetPort` to the service port name rather than the numeric port, or referencing a label key that does not exist on the pod template.
+
+## Supporting Resources
+
+Designs may include `ConfigMap`, `Secret` (as opaque placeholders - never real secrets in a design file), `ServiceAccount`, `PersistentVolumeClaim`, and many other resource kinds. Each must specify the correct `apiVersion` for the resource kind - for example, `apps/v1` for Deployments and `v1` for ConfigMaps.
+
+| Kind | apiVersion |
+|------|-----------|
+| Namespace | v1 |
+| Deployment | apps/v1 |
+| Service | v1 |
+| ConfigMap | v1 |
+| StatefulSet | apps/v1 |
+| Ingress | networking.k8s.io/v1 |
+| ServiceAccount | v1 |
+
+Getting `apiVersion` wrong is the single most frequent LLM error and always causes an import failure.
+
+## What Meshery Checks at Import
+
+When you run `mesheryctl design import -f <file> -s "Kubernetes Manifest"`, Meshery performs three operations in sequence:
+
+1. **Parse** - split the file on `---` delimiters and parse each document as YAML.
+2. **Identify** - look up each `kind`/`apiVersion` pair against the Meshery component registry. Unknown combinations are flagged as unrecognised components.
+3. **Validate** - check required fields and relationships (for example, that a Deployment's selector matches its pod template labels).
+
+A design that passes all three steps appears in the Meshery Designs panel and can be opened in Kanvas for visual editing and deployment. Failures at any step are reported in the CLI output with enough detail to point you to the offending document.
+
+## Key Takeaways
+
+- A Meshery design is valid Kubernetes YAML with `---` document separators.
+- Namespace first, then Deployments, then Services and supporting resources.
+- Selectors must match pod template labels exactly.
+- Include resource requests and limits on every container.
+- Use the correct `apiVersion` for each resource kind.
+- The import command is `mesheryctl design import -f <file> -s "Kubernetes Manifest"`.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/generating-meshery-designs-with-llms/generating-designs/getting-models-and-relationships-right/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/generating-meshery-designs-with-llms/generating-designs/getting-models-and-relationships-right/_index.md
@@ -1,0 +1,117 @@
+---
+type: "page"
+id: "getting-models-and-relationships-right"
+title: "Getting Models and Relationships Right"
+description: "Align generated designs with the Meshery registry and understand how validation catches common LLM mistakes."
+weight: 3
+---
+
+Meshery does not treat a design as a bag of YAML documents. It maps every resource in your design to a registered component - a typed, versioned entity in the Meshery registry. If the mapping fails, the resource is marked as unrecognised and cannot be managed, visualised, or deployed through Meshery. This lesson explains the registry model, the most common ways LLM-generated YAML breaks it, and how to use Meshery's validation to close the gap.
+
+## The Meshery Registry
+
+The Meshery registry is a catalogue of models, components, and relationships. Understanding each level helps you understand what can go wrong.
+
+**Models** correspond to integrations - Kubernetes core, Istio, Prometheus, NGINX, and so on. Each model is versioned and describes a set of components that Meshery knows how to manage.
+
+**Components** are the individual resource types within a model. The Kubernetes core model, for example, contains components for Deployment, Service, ConfigMap, Namespace, and many others. Each component is identified by its `kind` and `apiVersion`.
+
+**Relationships** describe how components connect to each other - for example, that a Service's `selector` should match a Deployment's pod template labels, or that a Pod's `serviceAccountName` should reference a ServiceAccount in the same namespace. Relationships are evaluated during validation and visualised in Kanvas as connectors between component nodes.
+
+When you import a design, Meshery resolves every `kind`/`apiVersion` pair against the registry. A pair that is not in the registry produces a warning; a pair that is present but with the wrong version produces a type mismatch error. Both prevent full management of the affected resource.
+
+## Common Mistakes in LLM-Generated Designs
+
+### Wrong apiVersion
+
+This is the most frequent failure. LLMs trained on older data may produce deprecated API groups:
+
+| LLM output | Correct |
+|-----------|---------|
+| `extensions/v1beta1` for Deployment | `apps/v1` |
+| `apps/v1beta1` for StatefulSet | `apps/v1` |
+| `networking.k8s.io/v1beta1` for Ingress | `networking.k8s.io/v1` |
+| `rbac.authorization.k8s.io/v1beta1` | `rbac.authorization.k8s.io/v1` |
+
+The Kubernetes API server removed these versions in 1.16-1.22. Meshery's registry reflects current, supported API versions. Any deprecated version will either fail the Meshery component lookup or be rejected by the cluster on deployment.
+
+### Selector Mismatch
+
+A Deployment's `spec.selector.matchLabels` must be an exact subset of `spec.template.metadata.labels`. LLMs occasionally produce designs where the selector references a label that is not present on the pod template, or adds a label to the template that is not in the selector.
+
+```yaml
+# Broken - selector key does not appear in template labels
+spec:
+  selector:
+    matchLabels:
+      app: api
+      tier: backend       # not in template
+  template:
+    metadata:
+      labels:
+        app: api          # selector key present
+        component: api    # different key from selector
+```
+
+Meshery flags this as a relationship validation failure. The relationship rule for Deployment-to-Pod requires that `matchLabels` is a subset of template labels.
+
+### Missing Resource Limits
+
+Deployments without resource requests and limits are common in tutorial YAML but problematic in practice. Meshery's validation marks containers without `resources.requests` and `resources.limits` with a warning. Clusters with a `LimitRange` admission controller will reject them outright.
+
+```yaml
+# Always include resource constraints
+resources:
+  requests:
+    cpu: "50m"
+    memory: "64Mi"
+  limits:
+    cpu: "200m"
+    memory: "128Mi"
+```
+
+### Service targetPort Mismatch
+
+A Service's `targetPort` must match a `containerPort` declared in the referenced pod spec. LLMs sometimes invent port numbers or use port names that do not exist in the Deployment.
+
+```yaml
+# Broken - targetPort 8080 does not match containerPort 9898
+spec:
+  ports:
+    - port: 80
+      targetPort: 8080    # wrong
+
+# Correct - matches containerPort in Deployment
+spec:
+  ports:
+    - port: 9898
+      targetPort: 9898
+```
+
+Meshery's relationship validation for Service-to-Deployment checks this alignment and flags mismatches.
+
+## How Validation Surfaces These Issues
+
+After import, open the design in Kanvas. The visual canvas shows each component as a node. Components with validation errors are highlighted, and hovering over the error indicator shows the specific issue - wrong apiVersion, selector mismatch, missing field, or relationship failure.
+
+You can also run `mesheryctl system check` to verify that your Meshery instance is healthy and connected to the cluster before attempting deployment. A healthy instance produces accurate validation output; a disconnected one may miss relationship errors that require cluster-side admission.
+
+For designs that fail import entirely, the CLI output from `mesheryctl design import` includes the document index and the specific parsing or identification error. Use this to locate the offending `---` block in your YAML file.
+
+## Registry-Aligned Prompt Additions
+
+Add these lines to any LLM prompt to prevent the most common registry mismatches:
+
+```text
+- Use only stable, non-deprecated Kubernetes API versions:
+  apps/v1 for Deployments and StatefulSets,
+  networking.k8s.io/v1 for Ingress,
+  rbac.authorization.k8s.io/v1 for ClusterRole and ClusterRoleBinding,
+  v1 for everything else (Namespace, Service, ConfigMap, Secret, ServiceAccount)
+- selector.matchLabels on every Deployment must exactly match the pod template labels
+- Every container must have resources.requests.cpu, resources.requests.memory,
+  resources.limits.cpu, and resources.limits.memory
+- Service targetPort values must be numeric and match a containerPort in the corresponding Deployment
+```
+
+These four constraints eliminate the four most common registry alignment failures in a single prompt addition.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/generating-meshery-designs-with-llms/generating-designs/iterating-and-refining-generated-designs/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/generating-meshery-designs-with-llms/generating-designs/iterating-and-refining-generated-designs/_index.md
@@ -1,0 +1,118 @@
+---
+type: "page"
+id: "iterating-and-refining-generated-designs"
+title: "Iterating and Refining Generated Designs"
+description: "Use targeted follow-up prompts and Kanvas validation to converge on a correct, deployable Meshery design."
+weight: 4
+---
+
+Generating a design that passes import on the first attempt is the goal, but it is not always the outcome. More often, the initial output is 80-90% correct and needs targeted corrections. The disciplined approach is to refine with surgical follow-up prompts, validate each change in Kanvas, and converge incrementally - not to regenerate from scratch and repeat the same mistakes.
+
+## Why Regeneration Is the Wrong Default
+
+When a design fails validation, the instinct is to re-run the original prompt and hope for a different result. That approach has two problems:
+
+1. LLM output is probabilistic. The model may produce the same error again, or introduce new errors while fixing the one you found.
+2. You lose the parts of the design that were already correct. A full regeneration discards good work.
+
+The better model is surgical: identify the specific validation failure, construct a follow-up prompt that addresses only that failure, apply the fix, and validate again. Each iteration is small, targeted, and verifiable.
+
+## Step 1 - Import and Read the Error
+
+Start every iteration cycle by importing the current design:
+
+```bash
+mesheryctl design import -f designs/my-design.yaml -s "Kubernetes Manifest"
+```
+
+Read the CLI output carefully. Import errors include:
+
+- The YAML document index where parsing failed
+- The `kind`/`apiVersion` pair that was not recognised
+- The field name that is missing or invalid
+
+If the import succeeds, open the design in Kanvas. Validation errors that do not block import (such as missing resource limits or relationship mismatches) appear as component-level warnings in the canvas.
+
+## Step 2 - Construct a Targeted Follow-Up Prompt
+
+Do not paste the entire failed design back into the LLM and ask it to fix everything. That produces another wide-output response that is hard to review. Instead, paste only the failing document (the specific `---` block) and describe the exact error:
+
+```text
+The following Kubernetes Service YAML fails Meshery validation with the error:
+"targetPort 8080 does not match any containerPort declared in the selected Deployment".
+
+The corresponding Deployment exposes containerPort 9898.
+
+Fix only the Service spec below to correct the targetPort. Return only the corrected YAML
+for this Service, no explanation:
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  namespace: demo
+spec:
+  selector:
+    app: api
+  ports:
+    - port: 9898
+      targetPort: 8080   # wrong
+```
+
+This prompt is unambiguous: it names the error, explains the correct value, restricts the output to the failing document, and asks for YAML only. The response should be a corrected Service block that you can splice back into the full design.
+
+## Step 3 - Splice and Re-import
+
+Replace the failing document in your design file with the corrected block and re-run the import:
+
+```bash
+mesheryctl design import -f designs/my-design.yaml -s "Kubernetes Manifest"
+```
+
+If the import passes, open Kanvas to verify the visual layout and check for remaining warnings. If a new error appears, go back to step 2 with the new error message.
+
+## Step 4 - Validate in Kanvas
+
+Kanvas is the human-in-the-loop checkpoint. After each successful import, open the design and do three checks:
+
+1. **Topology** - do the component nodes and connectors reflect the intended architecture? A Service should connect to its target Deployment. A ConfigMap should be mounted where you expect.
+2. **Warnings** - are there any yellow or red indicator badges on component nodes? Click each one to read the validation message.
+3. **Completeness** - are all expected resources present? Kanvas makes it easy to spot a missing ServiceAccount or an orphaned ConfigMap that has no consumer.
+
+If a warning is acceptable (for example, an image without a pinned digest in a development design), note it in your design metadata as a known exception. Do not silently ignore it.
+
+## A Realistic Iteration Example
+
+Starting from a generated design based on `designs/microservices-demo.yaml`:
+
+| Iteration | Error found | Follow-up prompt |
+|-----------|------------|-----------------|
+| 1 | Import fails: `extensions/v1beta1` not recognised | "Change apiVersion to apps/v1 on all Deployments. Return only the corrected Deployment blocks." |
+| 2 | Import passes; Kanvas shows selector mismatch on `cache` Deployment | "The cache Deployment selector.matchLabels has key `component` but template.metadata.labels has key `app`. Fix the selector to match the template. Return only the corrected Deployment." |
+| 3 | Import passes; Kanvas shows missing resource limits on cache container | "Add resources.requests and resources.limits to the cache container. Use cpu: 50m/200m and memory: 32Mi/64Mi. Return only the corrected container spec." |
+| 4 | All validations pass | None - design is ready |
+
+Four iterations, each targeting one specific problem. This is faster and more reliable than two or three full regenerations.
+
+## When to Start Fresh
+
+Starting from scratch is appropriate when:
+
+- The initial output has the wrong structure entirely (for example, Helm chart syntax instead of plain YAML)
+- More than half the documents have errors and the errors are in the structure rather than individual field values
+- The model has hallucinated resource kinds that do not exist in the Meshery registry and cannot be mapped to real kinds
+
+In these cases, go back to the prompting techniques from the previous lesson, add the constraints that were missing, and generate again with a cleaner prompt.
+
+## Convergence Criterion
+
+A design has converged when:
+
+- `mesheryctl design import` completes without errors
+- Kanvas shows no red validation badges
+- The topology in Kanvas matches the intended architecture
+- All containers have resource requests and limits
+- All selector/label pairs are consistent
+
+At that point the design is importable, visualisable, and deployable. Save it to the Meshery Catalog or commit it to your repository so it can be referenced in future iterations.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/generating-meshery-designs-with-llms/generating-designs/prompting-an-llm-to-produce-design-yaml/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/generating-meshery-designs-with-llms/generating-designs/prompting-an-llm-to-produce-design-yaml/_index.md
@@ -1,0 +1,131 @@
+---
+type: "page"
+id: "prompting-an-llm-to-produce-design-yaml"
+title: "Prompting an LLM to Produce Design YAML"
+description: "Craft prompts that reliably produce correct, importable Kubernetes YAML from an LLM."
+weight: 2
+---
+
+Asking an LLM to "write Kubernetes YAML for my app" produces wildly variable results - sometimes correct, often not. The gap between a vague request and a reliable output is almost entirely in how you prompt. This lesson covers the techniques that consistently get importable designs on the first attempt.
+
+## The Core Problem with Open-Ended Prompts
+
+LLMs are trained on enormous amounts of Kubernetes YAML, but that corpus contains old API versions, deprecated fields, inconsistent resource limits, and patterns from dozens of different toolchains. An open-ended prompt lets the model sample from all of that equally. The result is output that looks plausible but fails import because of a wrong `apiVersion`, a missing `selector`, or an ambiguous `targetPort`.
+
+The fix is constraint: give the model enough specifics that it has no room to guess.
+
+## Technique 1 - Specify Every Resource Kind
+
+Name the exact Kubernetes resource kinds you want. Do not ask for "a deployment and some services" - list them explicitly.
+
+```text
+Generate valid Kubernetes YAML for a three-tier application.
+Include exactly these resources in this order:
+1. Namespace named "demo" with label app.kubernetes.io/part-of: demo
+2. Deployment named "frontend" in namespace "demo", image nginx:1.27-alpine, 2 replicas
+3. Service named "frontend" in namespace "demo", ClusterIP, port 80 targeting containerPort 80
+4. Deployment named "api" in namespace "demo", image ghcr.io/stefanprodan/podinfo:6.6.2, 1 replica
+5. Service named "api" in namespace "demo", ClusterIP, port 9898 targeting containerPort 9898
+
+Requirements:
+- Use apiVersion apps/v1 for Deployments, v1 for Namespace and Service
+- Each Deployment must have selector.matchLabels that exactly matches template.metadata.labels
+- Every container must have resources.requests and resources.limits
+- Separate each document with ---
+- Output only the YAML, no explanation
+```
+
+The "output only the YAML" instruction is important. Without it, the model wraps the output in prose, which breaks the import parser if any text appears before the first `---`.
+
+## Technique 2 - Ground the Prompt in Real Component Kinds
+
+The Meshery registry recognises components by their `kind` and `apiVersion` combination. Grounding your prompt in real, current kinds prevents the model from inventing deprecated or fictional types.
+
+Good prompt additions:
+
+```text
+Use only these resource kinds:
+- v1/Namespace
+- apps/v1/Deployment
+- v1/Service
+- v1/ConfigMap
+- v1/ServiceAccount
+- networking.k8s.io/v1/Ingress
+
+Do not use any custom resource definitions or beta API versions.
+```
+
+This constraint eliminates two common failure modes: the model using `extensions/v1beta1/Deployment` (long deprecated) and the model hallucinating a custom resource kind it saw in training data.
+
+## Technique 3 - State Constraints Explicitly
+
+Constraints are anything the model cannot infer from the resource list alone:
+
+- Namespace scope: "all resources except the Namespace itself must set `namespace: demo`"
+- Label consistency: "the label key `app` must appear on pods and be referenced in Service selectors"
+- Resource limits: "every container must declare cpu and memory requests and limits; use conservative values appropriate for a development environment"
+- Port alignment: "containerPort values in Deployments must match targetPort values in Services"
+
+A prompt with explicit constraints reads longer, but it eliminates the most common validation failures before the model even outputs a character.
+
+## Technique 4 - Provide a Reference Example
+
+If you have a working design - such as `designs/microservices-demo.yaml` - paste a representative excerpt into the prompt as a reference pattern:
+
+```text
+Use the following as a structural template. Match its label scheme,
+document ordering, and resource field conventions:
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tcslabs-demo
+  labels:
+    app.kubernetes.io/part-of: tcslabs-academy
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: tcslabs-demo
+...
+
+Now generate a similar design for the following specification: [your spec here]
+```
+
+Providing a concrete example is more reliable than describing the pattern in prose. The model matches the structure of what it sees rather than interpreting abstract instructions.
+
+## Technique 5 - One Shot vs. Iterative Generation
+
+For simple designs (two or three services), a single well-constrained prompt usually produces something importable. For complex designs - multiple tiers, custom RBAC, Ingress routing, PersistentVolumeClaims - use iterative generation:
+
+1. Generate the core resources (Namespace, Deployments, Services) in one prompt.
+2. In a follow-up prompt, add the ConfigMaps and ServiceAccounts.
+3. In another follow-up, add the Ingress and RBAC resources.
+
+Each round is smaller and easier to verify. You can import the partial design after each step and catch problems early rather than debugging a 200-line file that fails somewhere in the middle.
+
+## A Complete Prompt Template
+
+```text
+You are generating a Kubernetes manifest for import into Meshery.
+
+Application: [your app name]
+Namespace: [name]
+
+Resources required (in this order):
+1. Namespace
+2. [list each resource with name, image, replicas, ports]
+
+Constraints:
+- apiVersion: apps/v1 for Deployments and StatefulSets; v1 for Namespace, Service, ConfigMap
+- selector.matchLabels must exactly match template.metadata.labels on every Deployment
+- All resources except Namespace must set namespace: [name]
+- Every container must include resources.requests and resources.limits
+- Service targetPort values must match containerPort values in the corresponding Deployment
+- Separate each resource with ---
+- Output only YAML, no prose before or after
+```
+
+Copy this template, fill in your specifics, and you have a prompt that will produce an importable design the majority of the time. The next lesson covers what to do when the output is close but not quite right.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/generating-meshery-designs-with-llms/generating-designs/quiz.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/generating-meshery-designs-with-llms/generating-designs/quiz.md
@@ -1,0 +1,78 @@
+---
+title: "Module Quiz"
+passPercentage: 70
+type: "test"
+questions:
+  - id: "q1"
+    text: "What CLI flag tells Meshery to treat an imported file as a Kubernetes manifest?"
+    type: "single-answer"
+    marks: 2
+    explanation: "The -s flag specifies the design source type. 'Kubernetes Manifest' is the correct value when importing standard Kubernetes YAML files."
+    options:
+      - id: "a"
+        text: "-t \"Kubernetes Manifest\""
+        isCorrect: false
+      - id: "b"
+        text: "-s \"Kubernetes Manifest\""
+        isCorrect: true
+      - id: "c"
+        text: "--format kubernetes"
+        isCorrect: false
+      - id: "d"
+        text: "--source-type manifest"
+        isCorrect: false
+  - id: "q2"
+    text: "Which of the following are common LLM mistakes that cause Meshery import or validation failures? Select all that apply."
+    type: "multiple-answers"
+    marks: 2
+    explanation: "Deprecated apiVersions are not recognised by the Meshery registry. A selector that does not match pod template labels fails Kubernetes admission and Meshery relationship validation. Missing resource limits trigger validation warnings. Using correct, stable apiVersions and matching selectors are requirements, not mistakes."
+    options:
+      - id: "a"
+        text: "Using apiVersion extensions/v1beta1 for a Deployment"
+        isCorrect: true
+      - id: "b"
+        text: "Setting selector.matchLabels to a key not present in pod template labels"
+        isCorrect: true
+      - id: "c"
+        text: "Using apiVersion apps/v1 for a Deployment"
+        isCorrect: false
+      - id: "d"
+        text: "Omitting resource requests and limits from container specs"
+        isCorrect: true
+  - id: "q3"
+    text: "When refining a design that fails validation, what is the recommended approach?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Surgical, targeted follow-up prompts that address only the failing document preserve the correct parts of the design and produce a smaller, verifiable change. Regenerating the entire design discards correct work and may repeat the same errors."
+    options:
+      - id: "a"
+        text: "Regenerate the entire design from the original prompt and hope for different output"
+        isCorrect: false
+      - id: "b"
+        text: "Paste only the failing YAML document and the exact error into a follow-up prompt"
+        isCorrect: true
+      - id: "c"
+        text: "Edit the YAML manually without involving the LLM again"
+        isCorrect: false
+      - id: "d"
+        text: "Delete the failing resource and redeploy without it"
+        isCorrect: false
+  - id: "q4"
+    text: "In a Meshery design, what is the correct document order for reliable import?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Meshery's import parser resolves intra-design references in document order. Placing the Namespace first ensures that all subsequent resources can be scoped correctly during parsing."
+    options:
+      - id: "a"
+        text: "Services first, then Deployments, then Namespace"
+        isCorrect: false
+      - id: "b"
+        text: "Deployments first, then Services, then Namespace last"
+        isCorrect: false
+      - id: "c"
+        text: "Namespace first, then Deployments, then Services and supporting resources"
+        isCorrect: true
+      - id: "d"
+        text: "Document order does not matter for Meshery import"
+        isCorrect: false
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/generating-meshery-designs-with-llms/test.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/generating-meshery-designs-with-llms/test.md
@@ -1,0 +1,112 @@
+---
+title: "Course Test"
+passPercentage: 70
+type: "test"
+questions:
+  - id: "q1"
+    text: "What command imports a Kubernetes manifest file named 'my-app.yaml' into Meshery?"
+    type: "short-answer"
+    marks: 2
+    correctAnswer: "mesheryctl design import -f my-app.yaml -s \"Kubernetes Manifest\""
+    case_sensitive: false
+    explanation: "The mesheryctl design import command requires the -f flag for the file path and the -s flag specifying 'Kubernetes Manifest' as the source type."
+  - id: "q2"
+    text: "Which Kubernetes resource kinds map to apiVersion apps/v1?"
+    type: "multiple-answers"
+    marks: 2
+    explanation: "Deployment and StatefulSet both use apiVersion apps/v1. Namespace, Service, and ConfigMap all use apiVersion v1. Ingress uses networking.k8s.io/v1."
+    options:
+      - id: "a"
+        text: "Deployment"
+        isCorrect: true
+      - id: "b"
+        text: "Namespace"
+        isCorrect: false
+      - id: "c"
+        text: "StatefulSet"
+        isCorrect: true
+      - id: "d"
+        text: "Service"
+        isCorrect: false
+      - id: "e"
+        text: "ConfigMap"
+        isCorrect: false
+  - id: "q3"
+    text: "What does the Meshery registry use to identify a component in an imported design?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Meshery identifies each component in a design by the combination of its kind and apiVersion fields. If this pair is not in the registry, the resource is flagged as unrecognised."
+    options:
+      - id: "a"
+        text: "The resource name and namespace"
+        isCorrect: false
+      - id: "b"
+        text: "The kind and apiVersion combination"
+        isCorrect: true
+      - id: "c"
+        text: "The label selector and pod template"
+        isCorrect: false
+      - id: "d"
+        text: "The container image name"
+        isCorrect: false
+  - id: "q4"
+    text: "Which prompting techniques reliably reduce LLM design generation failures? Select all that apply."
+    type: "multiple-answers"
+    marks: 2
+    explanation: "Specifying exact resource kinds, adding 'output only YAML' to prevent prose wrapping, listing explicit constraints such as resource limits and selector requirements, and providing a reference example from a working design all reduce generation failures. Asking for a general Kubernetes template without specifics produces variable and often incorrect output."
+    options:
+      - id: "a"
+        text: "Listing exact resource kinds with names, images, and ports"
+        isCorrect: true
+      - id: "b"
+        text: "Instructing the model to output only YAML with no explanation"
+        isCorrect: true
+      - id: "c"
+        text: "Asking for a general Kubernetes template without specifying resource kinds"
+        isCorrect: false
+      - id: "d"
+        text: "Providing a reference excerpt from a working design such as designs/microservices-demo.yaml"
+        isCorrect: true
+      - id: "e"
+        text: "Explicitly stating resource limit constraints in the prompt"
+        isCorrect: true
+  - id: "q5"
+    text: "A Deployment in a generated design has selector.matchLabels: {app: api, tier: backend} but its pod template labels are {app: api, component: api}. What will Meshery report?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Meshery's relationship validation checks that a Deployment's selector.matchLabels is a subset of the pod template labels. The key 'tier' in the selector does not appear in the template labels, so Meshery flags this as a relationship validation failure."
+    options:
+      - id: "a"
+        text: "No error - Kubernetes allows selector keys that are not in the pod template"
+        isCorrect: false
+      - id: "b"
+        text: "An import parsing error before any validation runs"
+        isCorrect: false
+      - id: "c"
+        text: "A relationship validation failure because the selector key 'tier' is not in the pod template labels"
+        isCorrect: true
+      - id: "d"
+        text: "A warning about the container image tag only"
+        isCorrect: false
+  - id: "q6"
+    text: "A design has converged and is ready to deploy when which of the following are true? Select all that apply."
+    type: "multiple-answers"
+    marks: 2
+    explanation: "A converged design must pass import without errors, show no red validation badges in Kanvas, have topology that matches the intended architecture, and have all containers with resource requests and limits. An LLM generating it without errors is not a convergence criterion - only Meshery import and Kanvas validation determine correctness."
+    options:
+      - id: "a"
+        text: "mesheryctl design import completes without errors"
+        isCorrect: true
+      - id: "b"
+        text: "Kanvas shows no red validation badges"
+        isCorrect: true
+      - id: "c"
+        text: "The LLM generated the design without any follow-up prompts"
+        isCorrect: false
+      - id: "d"
+        text: "All containers have resource requests and limits"
+        isCorrect: true
+      - id: "e"
+        text: "The topology in Kanvas matches the intended architecture"
+        isCorrect: true
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/validating-ai-generated-infrastructure/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/validating-ai-generated-infrastructure/_index.md
@@ -1,0 +1,16 @@
+---
+type: "course"
+id: "validating-ai-generated-infrastructure"
+title: "4. Validating AI-Generated Infrastructure"
+description: "Learn how to rigorously validate AI-generated infrastructure designs in Meshery before they reach your cluster, using policy enforcement, shift-left checks, and reusable guardrails."
+weight: 4
+tags: ["ai","validation","policy"]
+categories: "AI"
+level: "intermediate"
+---
+
+An LLM can produce a syntactically valid Kubernetes manifest in seconds, but syntactic correctness is not the same as operational correctness. Missing resource limits, label selector mismatches, or absent NetworkPolicies pass a YAML linter yet cause outages or security gaps the moment they land in a cluster.
+
+This course teaches you to treat validation as a first-class step in the AI-assisted infrastructure workflow. You will learn how Meshery's model-driven policy engine catches semantic errors that plain schema checks miss, how to apply shift-left techniques to AI output before a single `kubectl apply` runs, and how to design durable guardrails that bound what generated infra can do. The course closes with a concrete review checklist you can carry into every pull request that contains AI-generated infrastructure.
+
+By the end of this course you will have a repeatable, tool-backed process for turning raw LLM output into production-grade, policy-compliant infrastructure designs.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/validating-ai-generated-infrastructure/test.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/validating-ai-generated-infrastructure/test.md
@@ -1,0 +1,103 @@
+---
+title: "Course Test"
+passPercentage: 70
+type: "test"
+questions:
+  - id: "q1"
+    text: "What is the key difference between schema validation and relationship validation in Meshery?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Schema validation checks whether the YAML is structurally well-formed. Relationship validation checks whether the operational wiring between components is semantically correct - for example, whether a Service's selector actually resolves to Pods in the design. A selector mismatch passes schema validation but fails relationship validation."
+    options:
+      - id: "a"
+        text: "Schema validation is faster; relationship validation is slower"
+        isCorrect: false
+      - id: "b"
+        text: "Schema validation checks structural correctness; relationship validation checks semantic wiring between components"
+        isCorrect: true
+      - id: "c"
+        text: "Schema validation runs in CI; relationship validation runs only in production"
+        isCorrect: false
+      - id: "d"
+        text: "Schema validation uses OPA; relationship validation uses the Kubernetes API"
+        isCorrect: false
+  - id: "q2"
+    text: "Which mesheryctl command imports an AI-generated Kubernetes manifest into Meshery for validation?"
+    type: "short-answer"
+    marks: 2
+    correctAnswer: "mesheryctl design import -f"
+    case_sensitive: false
+    explanation: "The correct command is `mesheryctl design import -f <file> -s \"Kubernetes Manifest\"`. This imports the file, resolves components against the registry, evaluates relationships, and runs any policy rules attached to the target environment."
+  - id: "q3"
+    text: "An AI-generated Deployment has replicas: 2 but no PodDisruptionBudget. What is the risk, and which checklist category covers it?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Without a PDB, a node drain or cluster upgrade can terminate both replicas simultaneously, causing a full service outage. The review checklist's Resources category requires a PDB for any Deployment with more than one replica."
+    options:
+      - id: "a"
+        text: "The Deployment may exceed namespace quota; covered by the Policy category"
+        isCorrect: false
+      - id: "b"
+        text: "Both replicas can be terminated simultaneously during a node drain; covered by the Resources category"
+        isCorrect: true
+      - id: "c"
+        text: "The container may run as root; covered by the Security category"
+        isCorrect: false
+      - id: "d"
+        text: "The image tag may be mutable; covered by the Correctness category"
+        isCorrect: false
+  - id: "q4"
+    text: "Which of the following guardrails protect a namespace from AI-generated workloads that omit resource constraints? Select all that apply."
+    type: "multiple-answers"
+    marks: 2
+    explanation: "ResourceQuota caps aggregate CPU, memory, and object counts for the entire namespace - bounding total consumption regardless of individual container limits. LimitRange injects default requests and limits into any container that omits them. Together they ensure that even incomplete AI-generated manifests cannot consume unbounded resources."
+    options:
+      - id: "a"
+        text: "ResourceQuota"
+        isCorrect: true
+      - id: "b"
+        text: "LimitRange"
+        isCorrect: true
+      - id: "c"
+        text: "PodDisruptionBudget"
+        isCorrect: false
+      - id: "d"
+        text: "NetworkPolicy"
+        isCorrect: false
+  - id: "q5"
+    text: "Why does the checklist's Security category require checking that container images use pinned tags or digests rather than the :latest tag?"
+    type: "single-answer"
+    marks: 2
+    explanation: "A mutable tag like :latest can silently resolve to a different image between deployments. This makes rollbacks unreliable and introduces unpredictable behavior when the upstream image changes. Pinned tags or digests ensure every deploy uses exactly the image that was reviewed."
+    options:
+      - id: "a"
+        text: "Because :latest images are always larger and consume more cluster resources"
+        isCorrect: false
+      - id: "b"
+        text: "Because mutable tags can silently resolve to different images between deployments, making rollbacks unreliable"
+        isCorrect: true
+      - id: "c"
+        text: "Because Meshery's registry does not support mutable tags"
+        isCorrect: false
+      - id: "d"
+        text: "Because Kubernetes rejects :latest images by default"
+        isCorrect: false
+  - id: "q6"
+    text: "In the shift-left validation sequence for AI-generated infrastructure, what happens at step 3 (policy evaluation) and what tool executes it?"
+    type: "single-answer"
+    marks: 2
+    explanation: "After schema validation and relationship resolution, Meshery runs OPA-based Rego rules that are attached to the target environment. These rules enforce organizational standards that no schema can express - such as requiring resource limits, banning :latest tags, or mandating specific label keys. The rules execute automatically during design import."
+    options:
+      - id: "a"
+        text: "Kubernetes applies admission webhooks using kube-apiserver"
+        isCorrect: false
+      - id: "b"
+        text: "The CI pipeline runs kubectl apply --dry-run against a live cluster"
+        isCorrect: false
+      - id: "c"
+        text: "Meshery evaluates OPA-based Rego rules attached to the target environment, enforcing standards that schema validation cannot express"
+        isCorrect: true
+      - id: "d"
+        text: "A human reviewer manually checks the manifest against a printed policy document"
+        isCorrect: false
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/validating-ai-generated-infrastructure/validation-and-guardrails/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/validating-ai-generated-infrastructure/validation-and-guardrails/_index.md
@@ -1,0 +1,10 @@
+---
+type: "module"
+id: "validation-and-guardrails"
+title: "Validation & Guardrails"
+description: "Apply Meshery's policy engine and Kubernetes admission controls to validate and bound AI-generated infrastructure designs before deployment."
+weight: 1
+tags: ["validation"]
+categories: "AI"
+level: "intermediate"
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/validating-ai-generated-infrastructure/validation-and-guardrails/a-review-checklist-for-ai-infra/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/validating-ai-generated-infrastructure/validation-and-guardrails/a-review-checklist-for-ai-infra/_index.md
@@ -1,0 +1,90 @@
+---
+type: "page"
+id: "a-review-checklist-for-ai-infra"
+title: "A Review Checklist for AI-Generated Infra"
+description: "A concrete, reusable checklist covering correctness, security, resources, policy, and rollback that engineers run before merging or deploying AI-generated infrastructure."
+weight: 4
+---
+
+## Why a Checklist
+
+Automated validation catches well-defined violations. A human reviewer catches everything else: intent drift (the design does not match the original requirement), implicit assumptions baked in by the LLM, and organizational context that no policy rule encodes.
+
+A checklist forces the reviewer to look at each risk category deliberately rather than skimming for obvious errors. The five categories below correspond to the most common failure modes in AI-generated infrastructure: correctness, security, resources, policy, and rollback readiness.
+
+Use this checklist on every pull request or design promotion that contains LLM-generated content, regardless of how confident you are in the agent's output.
+
+---
+
+## The Checklist
+
+### Category 1: Correctness
+
+These checks confirm that the design does what was intended.
+
+- [ ] **Intent match** - re-read the original requirement or prompt. Does the generated design implement what was asked for, or did the LLM substitute a related but different approach?
+- [ ] **Component completeness** - are all required components present? (Services, ConfigMaps, Secrets, Ingress, HPA, etc. as appropriate for the workload)
+- [ ] **Relationship wiring** - Meshery validation is clean. No selector/label mismatches. All Services resolve to at least one Pod in the design.
+- [ ] **Namespace assignment** - every resource targets the correct namespace. No resource is in `default` when it belongs in a scoped namespace.
+- [ ] **Image references** - all container images use pinned tags or digests. No `:latest` tags.
+- [ ] **Configuration sources** - all ConfigMaps and Secrets referenced by volumes or environment variables actually exist in the design or are documented as pre-existing.
+
+### Category 2: Security
+
+These checks prevent the design from expanding the attack surface.
+
+- [ ] **No root containers** - every container sets `securityContext.runAsNonRoot: true` or specifies a non-zero `runAsUser`.
+- [ ] **Read-only root filesystem** - where the workload permits it, `readOnlyRootFilesystem: true` is set.
+- [ ] **Dropped capabilities** - `capabilities.drop: ["ALL"]` is present; any required capabilities are explicitly added back and justified.
+- [ ] **No host path mounts** - no `hostPath` volumes unless specifically required and documented.
+- [ ] **NetworkPolicy present** - the design includes explicit NetworkPolicy rules or relies on a documented namespace-level default-deny that is already in place.
+- [ ] **RBAC scoped** - ServiceAccounts bind only the permissions the workload actually needs. No cluster-admin bindings.
+- [ ] **Secret handling** - Secrets are not embedded as plaintext in ConfigMaps or environment variable values. They reference a Secret object or an external secrets provider.
+
+### Category 3: Resources
+
+These checks protect cluster stability and cost.
+
+- [ ] **Limits declared** - every container has `resources.limits.cpu` and `resources.limits.memory`.
+- [ ] **Requests reasonable** - `resources.requests` values are proportionate. CPU requests are not zero; memory requests are not orders of magnitude below limits.
+- [ ] **Replica count appropriate** - Deployment/StatefulSet replica counts match the workload's availability and load expectations, not the LLM's default of `1`.
+- [ ] **HPA configured where needed** - workloads with variable load have a HorizontalPodAutoscaler. Min and max replicas are sensible for the namespace quota.
+- [ ] **PodDisruptionBudget present** - any Deployment with `replicas > 1` has an associated PDB with `minAvailable >= 1`.
+
+### Category 4: Policy
+
+These checks confirm the design complies with your organization's rules.
+
+- [ ] **Meshery policy report is clean** - import the design with `mesheryctl design import -f <file> -s "Kubernetes Manifest"` and confirm zero policy violations for the target environment.
+- [ ] **Required labels present** - team, cost-center, environment, and any other mandatory label keys are on every resource.
+- [ ] **Admission webhook compatibility** - if the cluster runs OPA Gatekeeper or Kyverno, verify the design passes locally or in a staging cluster before targeting production.
+- [ ] **ResourceQuota headroom** - the aggregate resources requested by this design fit within the remaining quota of the target namespace. Check current usage before submitting.
+
+### Category 5: Rollback Readiness
+
+These checks ensure you can recover quickly if the deploy goes wrong.
+
+- [ ] **Deployment strategy set** - `RollingUpdate` with a meaningful `maxUnavailable` and `maxSurge`. Avoid `Recreate` for stateless services.
+- [ ] **Health probes defined** - every container has `readinessProbe` and `livenessProbe`. Misconfigured probes are a leading cause of failed rollouts.
+- [ ] **Previous version documented** - the image tags and replica counts of the current running version are recorded in the PR or design commit message, so rollback is one command.
+- [ ] **Stateful data handled** - if the design includes StatefulSets or PersistentVolumeClaims, the data migration or retention plan is documented alongside the design change.
+
+---
+
+## Incorporating the Checklist into Your Workflow
+
+Store the checklist as a pull request template in your repository (`.github/pull_request_template.md`). Require reviewers to check off each item before approving a PR that contains AI-generated infrastructure.
+
+For designs managed in Meshery workspaces, add a custom annotation to track checklist completion:
+
+```yaml
+metadata:
+  annotations:
+    tcslabs.io/review-checklist-completed: "true"
+    tcslabs.io/reviewer: "your-username"
+    tcslabs.io/review-date: "2025-06-16"
+```
+
+This creates an auditable trail alongside the design itself. Combined with Meshery's policy validation output, it gives any future maintainer a clear picture of what was checked and when.
+
+The checklist is a living document. As your agent's output patterns evolve and as new failure modes surface in post-incident reviews, add items. A checklist that grows with operational experience is more valuable than a static template.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/validating-ai-generated-infrastructure/validation-and-guardrails/catching-misconfigurations-early/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/validating-ai-generated-infrastructure/validation-and-guardrails/catching-misconfigurations-early/_index.md
@@ -1,0 +1,122 @@
+---
+type: "page"
+id: "catching-misconfigurations-early"
+title: "Catching Misconfigurations Early"
+description: "Apply shift-left validation techniques to AI-generated manifests before any deployment command runs, with concrete examples of common misconfiguration patterns."
+weight: 2
+---
+
+## Shift Left in the AI Workflow
+
+"Shift left" means moving quality checks as early in the pipeline as possible - closer to authorship, farther from production. In a traditional workflow, that means running linters and schema checks in CI before a merge. In an AI-assisted workflow, it means validating LLM output before you even commit it to version control.
+
+The earlier you catch a misconfiguration, the cheaper it is to fix. A design error caught in Meshery before import costs one edit. The same error caught by a crashing Pod in staging costs a rollout, an incident, and an investigation.
+
+## Where Pre-Deploy Checks Fit
+
+The check sequence for AI-generated infrastructure looks like this:
+
+```text
+LLM output (YAML)
+    |
+    v
+1. Schema validation  <-- mesheryctl design import catches parse errors
+    |
+    v
+2. Relationship validation  <-- Meshery registry resolves component wiring
+    |
+    v
+3. Policy evaluation  <-- OPA rules enforce your environment's standards
+    |
+    v
+4. Human review  <-- you or a peer inspects the validated design in Kanvas
+    |
+    v
+5. Deploy
+```
+
+Steps 1-3 run automatically on import. Step 4 is the human-in-the-loop gate before any cluster operation.
+
+## Common Misconfiguration Patterns from LLM Output
+
+### 1. Missing Resource Limits
+
+An LLM often omits `resources.limits` because training data contains many manifests that skip them. Without limits, a single runaway container can starve other workloads on the node.
+
+```yaml
+# What the LLM produced - no limits
+containers:
+  - name: api
+    image: myregistry/api:1.4.2
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "128Mi"
+      # limits section missing entirely
+```
+
+Meshery's policy engine flags this if a `require-resource-limits` rule is active for the target environment. Fix: add explicit `limits` that are at least as large as `requests`.
+
+### 2. Selector / Label Mismatch
+
+LLMs that generate Service and Deployment in a single pass sometimes use slightly different label values across the two resources.
+
+```yaml
+# Deployment labels
+metadata:
+  labels:
+    app: payments-api
+    tier: backend
+
+# Service selector - note the different value
+spec:
+  selector:
+    app: payments   # <-- does not match "payments-api"
+```
+
+Meshery's relationship engine catches this during design validation: the Service's selector resolves to zero matching components, which surfaces as a `Network` relationship error.
+
+### 3. Wrong Namespace
+
+When prompted to generate resources for a "production" environment, an LLM may set `namespace: default` because that is the most common value in its training data. Resources in the wrong namespace miss namespace-scoped RBAC, NetworkPolicies, and ResourceQuotas.
+
+```yaml
+metadata:
+  name: order-processor
+  namespace: default   # should be: production
+```
+
+You can catch this with a Meshery policy rule that rejects resources whose namespace does not appear in an approved list for the target environment. The import-time policy report will flag every violating component.
+
+### 4. Inconsistent Replica Count and PodDisruptionBudget
+
+An LLM might generate a Deployment with `replicas: 1` alongside a PodDisruptionBudget that requires `minAvailable: 2`. This passes schema validation but is logically incoherent: the PDB makes it impossible to drain the single node hosting the only replica.
+
+Meshery's relationship validation can surface this via a policy rule that compares `Deployment.spec.replicas` against any associated PDB's `minAvailable` or `maxUnavailable`.
+
+## Running the Check Before Committing
+
+A practical pre-commit workflow:
+
+```bash
+# Validate locally before touching git
+mesheryctl design import -f generated-infra.yaml -s "Kubernetes Manifest"
+
+# Review the validation output - if any errors appear, fix the YAML and re-import
+# Only commit once the validation report shows no errors or policy violations
+```
+
+For teams using GitOps, add a CI step that imports the design to a Meshery instance configured for the target environment. The import command exits non-zero on policy violations, which blocks the merge.
+
+## Building a Pattern Library of Known Failures
+
+Keep a running list of misconfigurations you have caught in AI output for your specific stack. Feed that list back as few-shot examples in your agent's system prompt:
+
+```text
+KNOWN VALIDATION FAILURES - always check for these before returning YAML:
+- service selector must exactly match deployment .metadata.labels
+- resources.limits must be present on every container
+- namespace must be one of: staging, production (never "default")
+```
+
+This closes the feedback loop: validation findings improve the agent's future output, which reduces the manual review burden over time. Even so, do not remove the automated checks - the agent will still miss cases, and the checks are cheap to run.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/validating-ai-generated-infrastructure/validation-and-guardrails/designing-guardrails-for-generated-infra/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/validating-ai-generated-infrastructure/validation-and-guardrails/designing-guardrails-for-generated-infra/_index.md
@@ -1,0 +1,136 @@
+---
+type: "page"
+id: "designing-guardrails-for-generated-infra"
+title: "Designing Guardrails for Generated Infrastructure"
+description: "Use Kubernetes admission controls and Meshery policy to set hard boundaries on what AI-generated infrastructure can consume and do."
+weight: 3
+---
+
+## Guardrails vs. Validation
+
+Validation catches errors in a specific design. Guardrails are standing controls that constrain every design deployed to an environment - regardless of whether a human or an LLM authored it.
+
+The distinction matters because you cannot review every detail of every AI-generated manifest by hand as volume scales. Guardrails provide a safety net that operates independently of reviewer attention: even if something slips through code review, the cluster refuses to run it.
+
+This lesson covers four Kubernetes primitives that together form a practical guardrail suite for AI-generated workloads: ResourceQuota, LimitRange, NetworkPolicy, and PodDisruptionBudget.
+
+## ResourceQuota: Cap Namespace Resource Consumption
+
+A `ResourceQuota` sets hard ceilings on aggregate resource consumption within a namespace. An LLM that generates a fleet of services without resource limits can still be stopped from consuming unbounded memory or CPU if a quota is in place.
+
+```yaml
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: generated-infra-quota
+  namespace: production
+spec:
+  hard:
+    requests.cpu: "20"
+    requests.memory: "40Gi"
+    limits.cpu: "40"
+    limits.memory: "80Gi"
+    pods: "50"
+    services: "20"
+    persistentvolumeclaims: "10"
+```
+
+When a deploy would breach any quota, Kubernetes rejects it at admission. The quota does not care that the manifest came from an LLM.
+
+## LimitRange: Set Per-Container Defaults and Bounds
+
+A `LimitRange` operates at the container level. It sets default requests and limits for any container that omits them, and it enforces minimum and maximum bounds.
+
+```yaml
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: container-defaults
+  namespace: production
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: "500m"
+        memory: "256Mi"
+      defaultRequest:
+        cpu: "100m"
+        memory: "128Mi"
+      max:
+        cpu: "4"
+        memory: "4Gi"
+      min:
+        cpu: "50m"
+        memory: "64Mi"
+```
+
+LimitRange handles the common LLM failure of omitting `resources.limits` entirely: the admission controller injects defaults before the container starts, keeping the node safe even when the manifest was incomplete.
+
+## NetworkPolicy: Default-Deny with Explicit Allow
+
+An LLM generating microservice topologies rarely adds NetworkPolicies. The default Kubernetes network model allows all Pod-to-Pod traffic, so generated workloads often land in a flat, unrestricted network - even in production.
+
+Apply a namespace-level default-deny policy first:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: production
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+```
+
+Then require generated designs to explicitly declare the ingress and egress rules their workloads need. If a generated design lacks NetworkPolicies, nothing communicates - which surfaces the gap immediately in testing, rather than silently in production.
+
+## PodDisruptionBudget: Prevent Accidental Full Outage
+
+An LLM generating Deployments rarely co-generates PodDisruptionBudgets. Without a PDB, a node drain or cluster upgrade can terminate all replicas of a service simultaneously.
+
+```yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: api-pdb
+  namespace: production
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: api
+```
+
+A Meshery policy rule can enforce the presence of a PDB for any Deployment with `replicas > 1`. This rule runs at design import time and blocks promotion of designs that are missing disruption protection.
+
+## The `policy-guardrails.yaml` Design
+
+The academy ships a reference design that encodes the patterns above as importable Meshery components:
+
+```bash
+mesheryctl design import -f designs/policy-guardrails.yaml -s "Kubernetes Manifest"
+```
+
+After import, open the design in Kanvas. You will see:
+
+- A `ResourceQuota` component for the production namespace
+- A `LimitRange` component with sensible defaults for container workloads
+- A `NetworkPolicy` component implementing default-deny
+- Three `PodDisruptionBudget` components covering example service tiers
+
+Use this design as a template. Clone it in Kanvas, adjust the values for your environment, and deploy it to your target namespace before any AI-generated workloads land there. The guardrails will be active before the first generated manifest arrives.
+
+## Layering Guardrails with Meshery Environments
+
+Meshery environments let you associate a set of connections and configurations with a named target. When you attach policy rules to an environment, every design imported against that environment is evaluated against those rules.
+
+Configure your production environment to include:
+- A rule requiring `ResourceQuota` presence in the namespace
+- A rule verifying `LimitRange` is in place
+- A rule blocking any Deployment missing a PDB if `replicas > 1`
+- A rule rejecting default-deny-absent NetworkPolicy configurations
+
+These rules run automatically. Engineers importing AI-generated designs get immediate feedback on what is missing, without waiting for a human reviewer to notice.

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/validating-ai-generated-infrastructure/validation-and-guardrails/quiz.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/validating-ai-generated-infrastructure/validation-and-guardrails/quiz.md
@@ -1,0 +1,78 @@
+---
+title: "Module Quiz"
+passPercentage: 70
+type: "test"
+questions:
+  - id: "q1"
+    text: "A Meshery design contains a Service whose selector does not match any Pod labels in the design. Which validation mechanism catches this error?"
+    type: "single-answer"
+    marks: 2
+    explanation: "Meshery's registry resolves component relationships at import time. A Service-to-Pod network relationship that resolves to zero matching components is reported as a relationship error - not a schema error, since the YAML itself is structurally valid."
+    options:
+      - id: "a"
+        text: "YAML schema validation"
+        isCorrect: false
+      - id: "b"
+        text: "Meshery registry relationship evaluation"
+        isCorrect: true
+      - id: "c"
+        text: "LimitRange admission control"
+        isCorrect: false
+      - id: "d"
+        text: "ResourceQuota enforcement"
+        isCorrect: false
+  - id: "q2"
+    text: "Which Kubernetes primitive sets a default CPU limit for any container in a namespace that omits one?"
+    type: "single-answer"
+    marks: 2
+    explanation: "A LimitRange can specify default limits and default requests at the container level. When a container is admitted without explicit limits, the admission controller injects the LimitRange defaults automatically."
+    options:
+      - id: "a"
+        text: "ResourceQuota"
+        isCorrect: false
+      - id: "b"
+        text: "NetworkPolicy"
+        isCorrect: false
+      - id: "c"
+        text: "LimitRange"
+        isCorrect: true
+      - id: "d"
+        text: "PodDisruptionBudget"
+        isCorrect: false
+  - id: "q3"
+    text: "Which of the following are common misconfiguration patterns produced by LLMs that Meshery's pre-deploy checks catch? Select all that apply."
+    type: "multiple-answers"
+    marks: 2
+    explanation: "LLMs frequently omit resource limits (because much training data lacks them), produce selector/label mismatches between Services and Deployments, and assign resources to the wrong namespace. All three are caught by Meshery's relationship validation and policy engine before deployment."
+    options:
+      - id: "a"
+        text: "Missing container resource limits"
+        isCorrect: true
+      - id: "b"
+        text: "Service selector not matching Deployment labels"
+        isCorrect: true
+      - id: "c"
+        text: "Incorrect Hugo front matter"
+        isCorrect: false
+      - id: "d"
+        text: "Resources assigned to the wrong namespace"
+        isCorrect: true
+  - id: "q4"
+    text: "What is the primary purpose of applying a default-deny NetworkPolicy to a namespace before deploying AI-generated workloads?"
+    type: "single-answer"
+    marks: 2
+    explanation: "LLMs rarely generate NetworkPolicies. Without a default-deny baseline, all Pods in the namespace can communicate freely. A default-deny policy forces generated designs to explicitly declare the network access they need, surfacing gaps immediately in testing rather than silently in production."
+    options:
+      - id: "a"
+        text: "To limit aggregate CPU and memory consumption across the namespace"
+        isCorrect: false
+      - id: "b"
+        text: "To prevent node drains from terminating all replicas simultaneously"
+        isCorrect: false
+      - id: "c"
+        text: "To force generated designs to explicitly declare required network access"
+        isCorrect: true
+      - id: "d"
+        text: "To set default resource requests on containers that omit them"
+        isCorrect: false
+---

--- a/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/validating-ai-generated-infrastructure/validation-and-guardrails/relationship-and-policy-validation/_index.md
+++ b/content/learning-paths/deea6061-b6be-49a9-ad1c-f1a5c32e1fa9/ai-assisted-infrastructure-design-with-meshery-and-kanvas/validating-ai-generated-infrastructure/validation-and-guardrails/relationship-and-policy-validation/_index.md
@@ -1,0 +1,80 @@
+---
+type: "page"
+id: "relationship-and-policy-validation"
+title: "Relationship and Policy Validation"
+description: "Understand how Meshery validates designs through model relationships and policy rules, catching semantic errors a plain schema check cannot detect."
+weight: 1
+---
+
+## Beyond Schema Validation
+
+A YAML linter tells you whether a manifest is structurally well-formed. It does not tell you whether a Deployment's label selector actually matches the labels on its Pods, whether a Service points to Pods that exist in the design, or whether a container is missing the resource requests that a cluster policy requires. These are semantic errors - and they are exactly the category of mistake an LLM is most likely to introduce.
+
+Meshery addresses this through two layered mechanisms: the **registry** (models, components, and relationships) and the **policy engine**.
+
+## The Registry: Models, Components, and Relationships
+
+Every Kubernetes resource type - and resources from hundreds of other cloud native tools - is represented in the Meshery registry as a **component** belonging to a **model**. A component captures the schema for a resource; a **relationship** captures how two components interact.
+
+Relationships encode real operational semantics:
+
+| Relationship type | Example |
+|---|---|
+| Hierarchical | A Deployment owns ReplicaSets; a StatefulSet owns PersistentVolumeClaims |
+| Network | A Service selects Pods via `spec.selector` |
+| Permission | A ServiceAccount binds to a Role through a RoleBinding |
+| Volume | A Pod mounts a PersistentVolumeClaim |
+
+When you import a design - whether you authored it by hand or an LLM generated it - Meshery resolves each component against the registry and evaluates declared relationships. If a Service's selector does not match any Pod label set in the design, Meshery surfaces a relationship error. The error is semantic: the YAML was valid, but the wiring was wrong.
+
+## The Policy Engine
+
+On top of registry-level relationship checks, Meshery applies an **OPA-based policy engine** ([openpolicyagent.org](https://www.openpolicyagent.org)) that evaluates designs against Rego rules. Policies are attached to environments or workspaces and run automatically when a design is imported or saved.
+
+Policy rules can enforce constraints that no schema can express:
+
+- Every container must declare `resources.limits.cpu` and `resources.limits.memory`.
+- No Deployment may run containers as `root` (`securityContext.runAsNonRoot: true` must be present).
+- Images must reference a digest or a pinned tag - not `latest`.
+- Every workload must carry a `team` label from an approved set.
+
+When Meshery evaluates a design against these rules, it returns a structured report: which components violated which rules, with the path inside the component where the violation occurred. This is what a plain schema check cannot give you.
+
+## Importing and Validating a Design
+
+To see this in practice, import an AI-generated manifest using `mesheryctl`:
+
+```bash
+mesheryctl design import -f my-generated-design.yaml -s "Kubernetes Manifest"
+```
+
+Meshery processes the import, resolves components against the registry, evaluates relationships, and runs policy rules. Any errors appear in the Meshery UI under the design's **Validation** tab, and they are also printed to the CLI output.
+
+You can run a quick system check before importing to confirm your Meshery instance is healthy:
+
+```bash
+mesheryctl system check
+```
+
+## What Semantic Errors Look Like
+
+Here are concrete examples of errors that relationship and policy validation catch - and that a schema check would pass:
+
+```text
+[RELATIONSHIP ERROR] Service "api-svc": selector {app: api} matches 0 components in design.
+  Hint: Deployment "api" uses label {app: api-server}. Selector mismatch.
+
+[POLICY VIOLATION] Deployment "worker": container "processor" missing resources.limits.
+  Rule: all-containers-must-declare-limits (env: production)
+
+[POLICY VIOLATION] Deployment "frontend": container "nginx" image tag is "latest".
+  Rule: no-mutable-image-tags (env: production)
+```
+
+Each error identifies the component, the field path, and the rule that triggered it. This output is actionable: you know exactly what to fix and where.
+
+## Why This Matters for AI-Generated Infrastructure
+
+An LLM producing infrastructure from a natural-language prompt has no runtime awareness of your cluster's policies, your team's label conventions, or the relationship topology Meshery has modeled. It works from training data and context - which means it will produce plausible but subtly wrong wiring more often than a human expert would.
+
+Meshery's relationship and policy validation is the first automated gate in the human-in-the-loop workflow. It narrows the gap between "the LLM produced something" and "the design is safe to deploy." Treat its output as mandatory, not advisory: do not move a design forward until the validation report is clean.


### PR DESCRIPTION
## TCS Labs Academy — PR 3: Learning Path 3 (flagship, full content)

The flagship path: **AI-Assisted Infrastructure Design with Meshery & Kanvas**. Take infrastructure
from plain-language intent to a deployed, validated Meshery design - the core skill of an AI-native
platform engineer.

> **Stacked on [#12](https://github.com/meshery-extensions/tcslabs-academy/pull/12)** (foundation);
> base `feat/academy-foundation` so CI builds with scaffolding present. Independent of #13.

### Courses

| Course | Lessons |
|--------|---------|
| Designing Infrastructure with AI + Kanvas | from intent to topology · co-designing in Kanvas · describing infra in natural language · reviewing an AI-proposed design |
| Generating Meshery Designs with LLMs | anatomy of a Meshery design · prompting for design YAML · getting models & relationships right · iterating & refining |
| Agent-Driven Deployment | the deploy loop (agent + mesheryctl + GitOps) · dry-runs & diffs · deploying a design with an agent · rollback & recovery |
| Validating AI-Generated Infrastructure | relationship & policy validation · catching misconfigurations early · designing guardrails · a review checklist |

### By the numbers

- **16 lessons** (~12.9k words), **4 module quizzes**, **4 course tests**, **1 path exam**.
- Threads the academy's importable designs (`microservices-demo`, `observability-stack`,
  `llm-mcp-gateway`, `policy-guardrails`) through the hands-on lessons.

### Verification

- `hugo --gc --minify --buildDrafts --buildFuture` → **exit 0, 0 errors, 112 pages**.
- Style scan: no em-dashes, no commercial AI-vendor links. Content-ID registry messages are expected
  warnings.

### Next

PR 4 — Learning Path 4 (Coding Agents for Cloud Native Operations / Day-2).
