### PR TITLE
fix : updated discussion links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,4 +29,4 @@ assignees: ''
 ---
 #### Contributor Guide and Resources
 - 📚 [Instructions for contributing to tcslabs-academy](https://github.com/meshery-extensions/tcslabs-academy/blob/master/CONTRIBUTING.md)
-- 🙋🏾🙋🏼 Questions: [Discussion Forum](https://meshery.io/community#discussion-forums) and [Community Slack](http://slack.meshery.io)
+- 🙋🏾🙋🏼 Questions: [Discussion Forum](https://discuss.meshery.io) and [Community Slack](http://slack.meshery.io)

--- a/.github/ISSUE_TEMPLATE/ci.md
+++ b/.github/ISSUE_TEMPLATE/ci.md
@@ -20,4 +20,4 @@ assignees: ''
 ---
 #### Contributor Guide and Resources
 - 📚 [Instructions for contributing to tcslabs-academy](https://github.com/meshery-extensions/tcslabs-academy/blob/master/CONTRIBUTING.md)
-- 🙋🏾🙋🏼 Questions: [Discussion Forum](https://meshery.io/community#discussion-forums) and [Community Slack](http://slack.meshery.io)
+- 🙋🏾🙋🏼 Questions: [Discussion Forum](https://discuss.meshery.io) and [Community Slack](http://slack.meshery.io)

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -14,4 +14,4 @@ assignees: ''
 ---
 #### Contributor Guide and Resources
 - 📚 [Instructions for contributing to tcslabs-academy](https://github.com/meshery-extensions/tcslabs-academy/blob/master/CONTRIBUTING.md)
-- 🙋🏾🙋🏼 Questions: [Discussion Forum](https://meshery.io/community#discussion-forums) and [Community Slack](http://slack.meshery.io)
+- 🙋🏾🙋🏼 Questions: [Discussion Forum](https://discuss.meshery.io) and [Community Slack](http://slack.meshery.io)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -23,4 +23,4 @@ assignees: ''
 ---
 #### Contributor Guide and Resources
 - 📚 [Instructions for contributing to tcslabs-academy](https://github.com/meshery-extensions/tcslabs-academy/blob/master/CONTRIBUTING.md)
-- 🙋🙋 Questions: [Discussion Forum](https://meshery.io/community#discussion-forums) and [Community Slack](http://slack.meshery.io)
+- 🙋🙋 Questions: [Discussion Forum](https://discuss.meshery.io) and [Community Slack](http://slack.meshery.io)


### PR DESCRIPTION
**Notes for Reviewers**

This PR updates the community discussion forum link by replacing the [old URL](http://meshery.io/community#discussion-forums) with https://discuss.meshery.io.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
