### PR TITLE
[chore]: update workflow usage

### DIFF
--- a/.github/workflows/build-docs-preview.yml
+++ b/.github/workflows/build-docs-preview.yml
@@ -5,8 +5,7 @@ on:
     branches: [master]
     types: [opened, synchronize, reopened, closed]
     paths:
-      - 'docs/**'
-      - 'mesheryctl/doc/**'
+      - 'content/**'
       - '.github/workflows/build-docs-preview.yml'
       - '.github/workflows/deploy-docs-preview.yml'
       - '.github/workflows/docs-preview-cleanup.yml'
@@ -22,70 +21,71 @@ jobs:
   build-docs-preview:
     runs-on: ubuntu-24.04
     if: github.event.action != 'closed'
-    env:
-      HUGO_VERSION: 0.157.0
+    # env:
+    #   HUGO_VERSION: 0.158.0
 
     steps:
+      # Hugo Module fetching hits proxy.golang.org and sum.golang.org. Harmless under egress-policy: audit, but if the harden-runner is promoted to block,
+      # those two plus objects.githubusercontent.com must be in allowed-endpoints or the build dies at module resolution.
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
       - name: Checkout PR
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-          fetch-depth: 1
-          # Sparse checkout keeps the preview build focused on the Hugo site input
-          # instead of cloning the full repository, which materially reduces IO for
-          # docs-only previews triggered from pull_request.
-          sparse-checkout: |
-            docs
-            pr-preview
 
-      - name: Install Hugo CLI
-        run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+      # - name: Install Hugo CLI
+      #   run: |
+      #     wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+      #     && sudo dpkg -i ${{ runner.temp }}/hugo.deb
 
-      - name: Install Dart Sass
-        # Direct download from the dart-sass GitHub release rather than
-        # `sudo snap install dart-sass` (snap.io's storeserver was flaky
-        # in GitHub-hosted runners and broke this workflow on unrelated
-        # PRs, see #19574). Hugo Extended ships embedded Dart Sass as of
-        # v0.114+ but having the standalone binary on PATH is the most
-        # reliable path through `resources.toCSS` with transpiler "dartsass".
-        env:
-          DART_SASS_VERSION: 1.79.5
-        run: |
-          set -eu
-          cd "${RUNNER_TEMP}"
-          curl -fsSL -o dart-sass.tar.gz "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
-          sudo tar -xzf dart-sass.tar.gz -C /usr/local/lib
-          sudo ln -sf /usr/local/lib/dart-sass/sass /usr/local/bin/sass
-          sudo ln -sf /usr/local/lib/dart-sass/sass /usr/local/bin/dart-sass
-          dart-sass --version
+      # - name: Install Dart Sass
+      #   # Direct download from the dart-sass GitHub release rather than
+      #   # `sudo snap install dart-sass` (snap.io's storeserver was flaky
+      #   # in GitHub-hosted runners and broke this workflow on unrelated
+      #   # PRs, see #19574). Hugo Extended ships embedded Dart Sass as of
+      #   # v0.114+ but having the standalone binary on PATH is the most
+      #   # reliable path through `resources.toCSS` with transpiler "dartsass".
+      #   env:
+      #     DART_SASS_VERSION: 1.79.5
+      #   run: |
+      #     set -eu
+      #     cd "${RUNNER_TEMP}"
+      #     curl -fsSL -o dart-sass.tar.gz "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
+      #     sudo tar -xzf dart-sass.tar.gz -C /usr/local/lib
+      #     sudo ln -sf /usr/local/lib/dart-sass/sass /usr/local/bin/sass
+      #     sudo ln -sf /usr/local/lib/dart-sass/sass /usr/local/bin/dart-sass
+      #     dart-sass --version
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses:  actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
 
       - name: Install dependencies
         run: |
-          cd docs
-          [[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install
+          fi
 
       - name: Build PR preview
         env:
-          HUGO_ENVIRONMENT: production
-          HUGO_ENV: production
+          # HUGO_ENVIRONMENT: development
+          # HUGO_ENV: development
           HUGO_PREVIEW: "true"
-          PREVIEW_BASE_URL: "/pr-preview/pr-${{ github.event.pull_request.number }}/"
+          DEPLOY_PRIME_URL: "https://${{ github.repository_owner }}.github.io/academy/pr-preview/pr-${{ github.event.pull_request.number }}/"
         run: |
-          cd docs
-          npm run build:production -- --gc --baseURL "${PREVIEW_BASE_URL}"
-          find public -maxdepth 1 -type d -name 'v0.*' -exec rm -rf {} +
+          npm run build:preview
           cat > public/robots.txt <<'ROBOTS'
           User-agent: *
           Disallow: /
@@ -99,10 +99,10 @@ jobs:
             echo "${{ github.event.action }}" > ./pr/action
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: docs-preview-build
           path: |
-            ${{ github.event.action != 'closed' && 'docs/public' || '' }}
+            ${{ github.event.action != 'closed' && 'public' || '' }}
             pr/
           if-no-files-found: error

--- a/.github/workflows/build-docs-preview.yml
+++ b/.github/workflows/build-docs-preview.yml
@@ -66,7 +66,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Setup Node
-        uses:  actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
 
@@ -93,10 +93,10 @@ jobs:
 
       - name: Save PR Metadata
         run: |
-            mkdir -p ./pr
-            echo "${{ github.event.number }}" > ./pr/number
-            echo "${{ github.event.pull_request.head.sha }}" > ./pr/sha
-            echo "${{ github.event.action }}" > ./pr/action
+          mkdir -p ./pr
+          echo "${{ github.event.number }}" > ./pr/number
+          echo "${{ github.event.pull_request.head.sha }}" > ./pr/sha
+          echo "${{ github.event.action }}" > ./pr/action
 
       - name: Upload build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/build-docs-preview.yml
+++ b/.github/workflows/build-docs-preview.yml
@@ -6,6 +6,9 @@ on:
     types: [opened, synchronize, reopened, closed]
     paths:
       - 'content/**'
+      - '**.md'
+      - '**.go'
+      - 'hugo.yaml'
       - '.github/workflows/build-docs-preview.yml'
       - '.github/workflows/deploy-docs-preview.yml'
       - '.github/workflows/docs-preview-cleanup.yml'
@@ -36,6 +39,10 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
+      # hugo-extended is one of the dependencies which gets added onto the node_modules whenever npm install is run,
+      # so the commented out code below serves as a second installation of hugo within the runner.
+      # the commented out code is to be removed if the pr preview builds successfully.
 
       # - name: Install Hugo CLI
       #   run: |
@@ -80,8 +87,6 @@ jobs:
 
       - name: Build PR preview
         env:
-          # HUGO_ENVIRONMENT: development
-          # HUGO_ENV: development
           HUGO_PREVIEW: "true"
           DEPLOY_PRIME_URL: "/${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.pull_request.number }}/"
         run: |

--- a/.github/workflows/build-docs-preview.yml
+++ b/.github/workflows/build-docs-preview.yml
@@ -83,7 +83,7 @@ jobs:
           # HUGO_ENVIRONMENT: development
           # HUGO_ENV: development
           HUGO_PREVIEW: "true"
-          DEPLOY_PRIME_URL: "https://${{ github.repository_owner }}.github.io/academy/pr-preview/pr-${{ github.event.pull_request.number }}/"
+          DEPLOY_PRIME_URL: "/${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.pull_request.number }}/"
         run: |
           npm run build:preview
           cat > public/robots.txt <<'ROBOTS'

--- a/.github/workflows/deploy-docs-preview.yml
+++ b/.github/workflows/deploy-docs-preview.yml
@@ -49,6 +49,16 @@ jobs:
     needs: read-metadata
     runs-on: ubuntu-24.04
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout PR
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: true
+
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
@@ -60,7 +70,7 @@ jobs:
       - name: Deploy PR preview
         uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 #1.8.1
         with:
-          source-dir: ./docs-preview-build/docs/public
+          source-dir: ./docs-preview-build/public
           qr-code: false
           action: ${{ needs.read-metadata.outputs.action == 'closed' && 'remove' || 'deploy' }}
           pr-number: ${{ needs.read-metadata.outputs.pr-number }}

--- a/.github/workflows/deploy-docs-preview.yml
+++ b/.github/workflows/deploy-docs-preview.yml
@@ -42,8 +42,17 @@ jobs:
       - name: Retrieve PR metadata
         id: pr
         run: |
-          echo "PULL_REQUEST=$(cat ./docs-preview-build/pr/number)" >> "$GITHUB_OUTPUT"
-          echo "ACTION=$(cat ./docs-preview-build/pr/action)" >> "$GITHUB_OUTPUT"
+          number=$(head -n1 ./docs-preview-build/pr/number | tr -d '[:space:]')
+          case "$number" in ''|*[!0-9]*) echo "::error::invalid PR number"; exit 1 ;; esac
+
+          action=$(head -n1 ./docs-preview-build/pr/action | tr -d '[:space:]')
+          case "$action" in
+            opened|reopened|synchronize|closed) ;;
+            *) echo "::error::invalid action: $action"; exit 1 ;;
+          esac
+
+          echo "PULL_REQUEST=$number" >> "$GITHUB_OUTPUT"
+          echo "ACTION=$action" >> "$GITHUB_OUTPUT"
 
   deploy:
     needs: read-metadata
@@ -68,12 +77,27 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy PR preview
+        id: preview
         uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 #1.8.1
         with:
           source-dir: ./docs-preview-build/public
+          # previews are being served at the default `pages-base-url`
+          # if a cname is added, then the value of said custom domain must be given to `pages-base-url`
+          umbrella-dir: pr-preview # must match the /pr-preview/ baseURL the build bakes
           qr-code: false
+          comment: false
           action: ${{ needs.read-metadata.outputs.action == 'closed' && 'remove' || 'deploy' }}
           pr-number: ${{ needs.read-metadata.outputs.pr-number }}
+
+      - name: Comment preview URL
+        uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db # v2.9.2
+        with:
+          header: pr-preview
+          number: ${{ needs.read-metadata.outputs.pr-number }}
+          message: |
+            ${{ needs.read-metadata.outputs.action == 'closed'
+                && 'Preview removed because the pull request was closed.'
+                || format('📖 Pull request preview: {0}', steps.preview.outputs.preview-url) }}
 
   prune:
     needs: read-metadata

--- a/.github/workflows/deploy-docs-preview.yml
+++ b/.github/workflows/deploy-docs-preview.yml
@@ -8,7 +8,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  issues: write
   actions: read
 
 concurrency:
@@ -96,8 +95,8 @@ jobs:
           number: ${{ needs.read-metadata.outputs.pr-number }}
           message: |
             ${{ needs.read-metadata.outputs.action == 'closed'
-                && 'Preview removed because the pull request was closed.'
-                || format('📖 Pull request preview: {0}', steps.preview.outputs.preview-url) }}
+            && 'Preview removed because the pull request was closed.'
+            || format('📖 Pull request preview: {0}', steps.preview.outputs.preview-url) }}
 
   prune:
     needs: read-metadata
@@ -200,6 +199,7 @@ jobs:
               echo "removed_prs_json=$(printf '%s\n' "${removed_prs[@]}" | jq -R . | jq -sc .)"
             } >> "$GITHUB_OUTPUT"
           fi
+
       - name: Comment on pruned previews
         uses: actions/github-script@v8
         env:

--- a/.github/workflows/deploy-docs-preview.yml
+++ b/.github/workflows/deploy-docs-preview.yml
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: preview-post-build-${{ github.event.workflow_run.head_branch }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   PREVIEW_RETENTION_LIMIT: 6


### PR DESCRIPTION
**Notes for Reviewers**
- After merge, tests will be made over at https://github.com/meshery-extensions/tcslabs-academy/pull/62 to assure the functionality of the workflow
- This PR serves as the starting ground before the centralization, features and reviews from https://github.com/meshery-extensions/tcslabs-academy/pull/36 get added into the workflow in a future PR

## Summary
 
Adapts the ported docs preview pipeline (`build-docs-preview.yml` + `deploy-docs-preview.yml`) from the upstream Meshery template to this repository.
 
The template assumes a Hugo site living in a `docs/` subfolder of a large monorepo, with Hugo and Dart Sass installed as system binaries. This repository is the inverse: the Hugo site **is** the repository root, and the toolchain is resolved through npm. As a result the template does not run here as-is — most of the changes below are required for the pipeline to function at all, and are separated from the smaller optional improvements.
 
---
 
## Part 1 — Required adaptations
 
Changes without which the pipeline does not run, or produces incorrect output.
 
### 1. Trigger never fired
 
**`paths` filter:** `docs/**`, `mesheryctl/doc/**` → `content/**`
 
Neither upstream path exists in this repository, so no documentation change could ever trigger a preview build. The workflow was effectively inert.
 
### 2. Build ran against a non-existent directory
 
**Removed `sparse-checkout`.** The template restricted the checkout to two directories:
 
- `docs` — does not exist here; the site is at the repository root.
- `pr-preview` — exists only on the `gh-pages` branch. This checkout targets the PR source branch, where it has never existed. Sparse-checkout silently matches nothing rather than erroring, so this failed quietly.
**Removed every `cd docs`.** All build steps now operate from the repository root. Without this, the dependency install and build steps abort immediately.
 
### 3. Theme could not be resolved
 
**Added `actions/setup-go`.**
 
`hugo.yaml` imports the theme as a Hugo Module (`github.com/layer5io/academy-theme`) and there is no committed `_vendor/` directory. Hugo therefore shells out to `go mod download` at build time, which requires the Go toolchain on the runner. The upstream template did not need this. Version is read from `go.mod` via `go-version-file` so it cannot drift.
 
### 4. Build output would have been published from the wrong path
 
- **Build artifact:** `docs/public` → `public`
- **Deploy `source-dir`:** `./docs-preview-build/docs/public` → `./docs-preview-build/public`
The second is the consumer of the first; both had to move together or the deploy would find an empty directory.
 
### 5. Deploy job could not push
 
**Added `actions/checkout` to the `deploy` job**, with `persist-credentials: true`.
 
`pr-preview-action` publishes by committing to `gh-pages` and pushing — it is not an artifact upload. That requires a git repository, an `origin` remote, and a token in `.git/config`, all of which `actions/checkout` provides. The job previously only downloaded the artifact into a bare directory.
 
Note this deliberately differs from the build job, which uses `persist-credentials: false`. The build pushes nothing and should not hold a writable token; the deploy's entire purpose is the push.
 
Step ordering matters here and is intentional: **Harden Runner → checkout → download artifact**. `actions/checkout` clears its destination directory, so placing it after the download would delete the artifact.
 
### 6. Preview URLs would have been broken
 
**`baseURL` is now a full origin**, supplied via `DEPLOY_PRIME_URL`:
 
```
https://<org>.github.io/academy/pr-preview/pr-<N>/
```
 
The template passed a path-only value (`/pr-preview/pr-<N>/`). Two independent problems with that here:
 
- It omits the `/academy/` repository segment. A leading slash resolves from the domain root, so every stylesheet and image reference would 404.
- `hugo.yaml` sets `canonifyURLs: true`, which prepends `baseURL` verbatim during a post-render pass. A path-only base produces a relative `<loc>` in `sitemap.xml`, a relative `rel="canonical"`, and a broken RSS feed — all of which require an absolute URL by specification.
The explicit `--baseURL` flag was also dropped, because `package.json`'s `build:preview` script already reads `DEPLOY_PRIME_URL`. Passing both resulted in the flag being supplied twice.
 
### 7. Removed Meshery-specific output pruning
 
**Dropped `find public -maxdepth 1 -type d -name 'v0.*' -exec rm -rf {} +`.**
 
This stripped Meshery's versioned documentation directories from the preview to control artifact size. No such directories exist here, making it a no-op that could still fail the step if `public/` were ever absent.
 
---
 
## Part 2 — Behavioral change worth reviewer attention
 
**The preview now builds via `npm run build:preview` rather than `build:production`.**
 
This is a deliberate choice, not a mechanical port, and it changes what reviewers see. `build:preview` routes through the `_hugo-dev` script, which carries:
 
| Flag | Effect |
|---|---|
| `-D` | includes drafts |
| `-F` | includes future-dated content |
| `-E` | includes expired content |
| `-e dev` | builds in the `dev` environment |
 
So a PR preview shows content that **will not appear on the live site after merge** — a page still marked `draft: true` renders in review and then vanishes on publish. This is the right tradeoff for a docs review workflow, where seeing work-in-progress is the point, but it means the preview is not a merge simulation.
 
---
 
## Part 3 — Minor enhancements
 
Optional improvements. None are required for the pipeline to work.
 
### Removed redundant toolchain installs
 
**Hugo CLI install (commented out).** `hugo-extended` is pinned in `devDependencies`, and npm prepends `node_modules/.bin` to `PATH` for every `npm run`. The `.deb` downloaded by the template was therefore shadowed and never executed. Hugo's version now has a single source of truth in `package-lock.json`. Removes a `wget` + `dpkg` round trip per run.
 
**Dart Sass install (commented out).** The CSS pipeline here is `postcss-cli` + `autoprefixer`, both npm devDependencies. No use of the `dartsass` transpiler was found in the site or theme. Removes a `curl` + `tar` + two symlinks per run.
 
Both are commented rather than deleted pending a green run; they will be removed in a follow-up.
 
### Install failures are now visible
 
The template used:
 
```bash
[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true
```
 
The trailing `|| true` forces exit code 0 regardless of outcome, so a corrupt lockfile, a registry outage, or a lockfile out of sync with `package.json` all pass silently and surface much later as a confusing missing-module error during the Hugo build. Replaced with an explicit conditional that fails loudly. The shrinkwrap branch was dropped — that file is for published npm packages, which this is not.
 
### Supply-chain pinning
 
All actions in `build-docs-preview.yml` are now pinned to full commit SHAs, matching the existing `harden-runner` pin: `checkout`, `setup-go`, `setup-node`, `upload-artifact`. A tag can be silently repointed by the action's owner; a SHA cannot.
 
### Runner hardening parity
 
Added the `harden-runner` step to the `deploy` job, which previously had none while `read-metadata` did.
 
### Cosmetic
 
Dropped the explicit `fetch-depth: 1` from the build checkout. This is presentational only — `actions/checkout` defaults to a depth of 1, so the checkout remains shallow and behavior is unchanged.


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Documentation previews now rebuild when content, Markdown, Go, or site configuration changes.
  * Preview builds use the standard site build process and generated site artifacts.
  * Improved workflow security and validation for preview requests.

* **Bug Fixes**
  * Corrected preview deployments to use the generated site artifacts.
  * Improved cleanup when pull requests are closed.
  * Preview status updates now clearly display the preview link or closure notice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->